### PR TITLE
Consistently open context menu for hovered and selected entities

### DIFF
--- a/addons/context_menu/functions/fnc_openMenu.sqf
+++ b/addons/context_menu/functions/fnc_openMenu.sqf
@@ -28,6 +28,19 @@ private _category = ["OBJECT", "GROUP", "ARRAY", "STRING"] find _type;
 
 if (_category != -1) then {
     GVAR(selected) select _category pushBackUnique _entity;
+
+    // Add one man groups of hovered units to the selected groups array
+    // This makes opening the menu consistent when the unit is selected versus hovered
+    if (_type == "OBJECT" && {!isNull group _entity} && {count units _entity == 1}) then {
+        GVAR(selected) select 1 pushBackUnique group _entity;
+    };
+
+    // Add units of hovered groups to the selected units array to
+    // simulate selecting the group and then opening the menu
+    if (_type == "GROUP") then {
+        {GVAR(selected) select 0 pushBackUnique _x} forEach units _entity;
+    };
+
     GVAR(hovered) = _entity;
 } else {
     GVAR(hovered) = objNull;


### PR DESCRIPTION
**When merged this pull request will:**
- Consistently open context menu for one man groups when the unit is hovered versus selected, fix #20 
- For QOL, add units from a hovered group to the selected units array as if the unit was selected and then the menu was opened