### PR TITLE
Add skills button to attributes displays

### DIFF
--- a/addons/attributes/CfgEventHandlers.hpp
+++ b/addons/attributes/CfgEventHandlers.hpp
@@ -9,3 +9,9 @@ class Extended_PreInit_EventHandlers {
         init = QUOTE(call COMPILE_FILE(XEH_preInit));
     };
 };
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
+    };
+};

--- a/addons/attributes/RscAttributes.hpp
+++ b/addons/attributes/RscAttributes.hpp
@@ -887,6 +887,10 @@ class GVAR(RscAttributesMan): GVAR(RscAttributesBase) {
             text = "$STR_A3_Arsenal";
             function = QFUNC(buttonArsenal);
         };
+        class Skills {
+            text = CSTRING(Skills);
+            function = QFUNC(buttonSkills);
+        };
     };
 };
 
@@ -1056,6 +1060,12 @@ class GVAR(RscAttributesGroup): GVAR(RscAttributesBase) {
         };
         class ButtonOK: ButtonOK {};
         class ButtonCancel: ButtonCancel {};
+    };
+    class buttons {
+        class Skills {
+            text = CSTRING(Skills);
+            function = QFUNC(buttonSkills);
+        };
     };
 };
 

--- a/addons/attributes/RscAttributes.hpp
+++ b/addons/attributes/RscAttributes.hpp
@@ -882,7 +882,7 @@ class GVAR(RscAttributesMan): GVAR(RscAttributesBase) {
         class ButtonOK: ButtonOK {};
         class ButtonCancel: ButtonCancel {};
     };
-    class buttons {
+    class Buttons {
         class Arsenal {
             text = "$STR_A3_Arsenal";
             function = QFUNC(buttonArsenal);
@@ -918,7 +918,7 @@ class GVAR(RscAttributesVehicle): GVAR(RscAttributesBase) {
         class ButtonOK: ButtonOK {};
         class ButtonCancel: ButtonCancel {};
     };
-    class buttons {
+    class Buttons {
         class Garage {
             text = "$STR_A3_Garage";
             function = QFUNC(buttonGarage);
@@ -948,7 +948,7 @@ class GVAR(RscAttributesVehicleEmpty): GVAR(RscAttributesBase) {
         class ButtonOK: ButtonOK {};
         class ButtonCancel: ButtonCancel {};
     };
-    class buttons {
+    class Buttons {
         class Garage {
             text = "$STR_A3_Garage";
             function = QFUNC(buttonGarage);
@@ -1061,7 +1061,7 @@ class GVAR(RscAttributesGroup): GVAR(RscAttributesBase) {
         class ButtonOK: ButtonOK {};
         class ButtonCancel: ButtonCancel {};
     };
-    class buttons {
+    class Buttons {
         class Skills {
             text = CSTRING(Skills);
             function = QFUNC(buttonSkills);

--- a/addons/attributes/XEH_PREP.hpp
+++ b/addons/attributes/XEH_PREP.hpp
@@ -21,5 +21,6 @@ PREP(attributeUnitPos);
 PREP(attributeWaypointTimeout);
 PREP(attributeWaypointType);
 PREP(buttonArsenal);
+PREP(buttonSkills);
 PREP(getAttributeEntities);
 PREP(initAttributesDisplay);

--- a/addons/attributes/XEH_postInit.sqf
+++ b/addons/attributes/XEH_postInit.sqf
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+
+[QGVAR(setSkills), {
+    params ["_unit", "_skills"];
+
+    {
+        _unit setSkill [_x, _skills select _forEachIndex];
+    } forEach [
+        "aimingAccuracy",
+        "aimingSpeed",
+        "aimingShake",
+        "commanding",
+        "courage",
+        "spotDistance",
+        "spotTime",
+        "reloadSpeed"
+    ];
+}] call CBA_fnc_addEventHandler;

--- a/addons/attributes/config.cpp
+++ b/addons/attributes/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"zen_common"};
+        requiredAddons[] = {"zen_dialog"};
         author = ECSTRING(main,Author);
         authors[] = {"mharis001"};
         url = ECSTRING(main,URL);

--- a/addons/attributes/functions/fnc_buttonSkills.sqf
+++ b/addons/attributes/functions/fnc_buttonSkills.sqf
@@ -1,0 +1,36 @@
+/*
+ * Author: mharis001
+ * Handles clicking the skills button.
+ *
+ * Arguments:
+ * 0: Button <CONTROL>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [CONTROL] call zen_attributes_fnc_buttonSkills
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+private _entity = GETMVAR(BIS_fnc_initCuratorAttributes_target,objNull);
+private _unit   = if (_entity isEqualType grpNull) then {leader _entity} else {_entity};
+
+[LSTRING(ChangeSkills), [
+    ["SLIDER:PERCENT", LSTRING(AimingAccuracy), [0, 1, _unit skill "aimingAccuracy"], true],
+    ["SLIDER:PERCENT", LSTRING(AimingSpeed),    [0, 1, _unit skill "aimingSpeed"   ], true],
+    ["SLIDER:PERCENT", LSTRING(AimingShake),    [0, 1, _unit skill "aimingShake"   ], true],
+    ["SLIDER:PERCENT", LSTRING(Commanding),     [0, 1, _unit skill "commanding"    ], true],
+    ["SLIDER:PERCENT", LSTRING(Courage),        [0, 1, _unit skill "courage"       ], true],
+    ["SLIDER:PERCENT", LSTRING(SpotDistance),   [0, 1, _unit skill "spotDistance"  ], true],
+    ["SLIDER:PERCENT", LSTRING(SpotTime),       [0, 1, _unit skill "spotTime"      ], true],
+    ["SLIDER:PERCENT", LSTRING(ReloadSpeed),    [0, 1, _unit skill "reloadSpeed"   ], true]
+], {
+    params ["_dialogValues", "_entity"];
+
+    {
+        [QGVAR(setSkills), [_x, _dialogValues], _x] call CBA_fnc_targetEvent;
+    } forEach (_entity call FUNC(getAttributeEntities));
+}, {}, _entity] call EFUNC(dialog,create);

--- a/addons/attributes/functions/fnc_initAttributesDisplay.sqf
+++ b/addons/attributes/functions/fnc_initAttributesDisplay.sqf
@@ -127,7 +127,7 @@ _ctrlButtonCancel ctrlCommit 0;
     _ctrlButton ctrlCommit 0;
     _ctrlButton ctrlSetText _buttonText;
     _ctrlButton ctrlAddEventHandler ["ButtonClick", _function];
-} forEach configProperties [_displayConfig >> "buttons", "isClass _x"];
+} forEach configProperties [_displayConfig >> "Buttons", "isClass _x"];
 
 // Add check to close the display when the entity is altered
 private _fnc_closeDisplay = {

--- a/addons/attributes/stringtable.xml
+++ b/addons/attributes/stringtable.xml
@@ -31,5 +31,35 @@
             <German>Zeit (in Sekunden) zwischen der Erfüllung der Wegpunktbedingung und der Vervollständigung des Wegpunktes.</German>
             <Polish>Czas (w sekundach) pomiędzy wypełnieniem warunku zaliczenia punktu trasy a jego faktycznym zaliczeniem.</Polish>
         </Key>
+        <Key ID="STR_ZEN_Attributes_ChangeSkills">
+            <English>Change Skills</English>
+        </Key>
+        <Key ID="STR_ZEN_Attributes_Skills">
+            <English>Skills</English>
+        </Key>
+        <Key ID="STR_ZEN_Attributes_AimingAccuracy">
+            <English>Aiming Accuracy</English>
+        </Key>
+        <Key ID="STR_ZEN_Attributes_AimingSpeed">
+            <English>Aiming Speed</English>
+        </Key>
+        <Key ID="STR_ZEN_Attributes_AimingShake">
+            <English>Aiming Shake</English>
+        </Key>
+        <Key ID="STR_ZEN_Attributes_Commanding">
+            <English>Commanding</English>
+        </Key>
+        <Key ID="STR_ZEN_Attributes_Courage">
+            <English>Courage</English>
+        </Key>
+        <Key ID="STR_ZEN_Attributes_SpotDistance">
+            <English>Spot Distance</English>
+        </Key>
+        <Key ID="STR_ZEN_Attributes_SpotTime">
+            <English>Spot Time</English>
+        </Key>
+        <Key ID="STR_ZEN_Attributes_ReloadSpeed">
+            <English>Reload Speed</English>
+        </Key>
     </Package>
 </Project>

--- a/addons/dialog/functions/fnc_create.sqf
+++ b/addons/dialog/functions/fnc_create.sqf
@@ -127,7 +127,7 @@ scopeName "Main";
         };
         case "SLIDER": {
             _valueInfo params [["_min", 0, [0]], ["_max", 1, [0]], ["_default", 0, [0]], ["_decimals", 2, [0]]];
-            _rowSettings append [_min, _max, _decimals];
+            _rowSettings append [_min, _max, _decimals, _subType == "PERCENT"];
             _defaultValue = _default;
             _controlType = QGVAR(Row_Slider);
         };

--- a/addons/dialog/functions/fnc_gui_slider.sqf
+++ b/addons/dialog/functions/fnc_gui_slider.sqf
@@ -18,30 +18,35 @@
  */
 #include "script_component.hpp"
 
+#define FORMAT_VALUE(value,decimals,isPercentage) (\
+    if (isPercentage) then { \
+        format ["%1%2", round (value * 100), "%"]; \
+    } else { \
+        [value, 1, decimals max 0] call CBA_fnc_formatNumber; \
+    })
+
 params ["_controlsGroup", "_rowIndex", "_currentValue", "_rowSettings"];
-_rowSettings params ["_min", "_max", "_decimals"];
-
-private _ctrlSlider = _controlsGroup controlsGroupCtrl IDC_ROW_SLIDER;
-
-_ctrlSlider sliderSetRange [_min, _max];
-_ctrlSlider sliderSetPosition _currentValue;
+_rowSettings params ["_min", "_max", "_decimals", "_isPercentage"];
 
 private _range = _max - _min;
-_ctrlSlider sliderSetSpeed [0.05 * _range, 0.1 * _range];
 
-_ctrlSlider setVariable [QGVAR(params), [_rowIndex, _decimals]];
+private _ctrlSlider = _controlsGroup controlsGroupCtrl IDC_ROW_SLIDER;
+_ctrlSlider sliderSetRange [_min, _max];
+_ctrlSlider sliderSetPosition _currentValue;
+_ctrlSlider sliderSetSpeed [0.05 * _range, 0.1 * _range];
+_ctrlSlider setVariable [QGVAR(params), [_rowIndex, _decimals, _isPercentage]];
 
 _ctrlSlider ctrlAddEventHandler ["SliderPosChanged", {
     params ["_ctrlSlider", "_value"];
-    (_ctrlSlider getVariable QGVAR(params)) params ["_rowIndex", "_decimals"];
+    (_ctrlSlider getVariable QGVAR(params)) params ["_rowIndex", "_decimals", "_isPercentage"];
+
+    private _controlsGroup = ctrlParentControlsGroup _ctrlSlider;
+    private _ctrlEdit = _controlsGroup controlsGroupCtrl IDC_ROW_SLIDER_EDIT;
+    _ctrlEdit ctrlSetText FORMAT_VALUE(_value,_decimals,_isPercentage);
 
     if (_decimals < 0) then {
         _value = round _value;
     };
-
-    private _controlsGroup = ctrlParentControlsGroup _ctrlSlider;
-    private _ctrlEdit = _controlsGroup controlsGroupCtrl IDC_ROW_SLIDER_EDIT;
-    _ctrlEdit ctrlSetText ([_value, 1, _decimals max 0] call CBA_fnc_formatNumber);
 
     private _display = ctrlParent _ctrlSlider;
     private _values = _display getVariable QGVAR(values);
@@ -49,17 +54,21 @@ _ctrlSlider ctrlAddEventHandler ["SliderPosChanged", {
 }];
 
 private _ctrlEdit = _controlsGroup controlsGroupCtrl IDC_ROW_SLIDER_EDIT;
-_ctrlEdit ctrlSetText ([_currentValue, 1, _decimals max 0] call CBA_fnc_formatNumber);
-_ctrlEdit setVariable [QGVAR(params), [_rowIndex, _decimals]];
+_ctrlEdit ctrlSetText FORMAT_VALUE(_currentValue,_decimals,_isPercentage);
+_ctrlEdit setVariable [QGVAR(params), [_rowIndex, _decimals, _isPercentage]];
 
 _ctrlEdit ctrlAddEventHandler ["KeyUp", {
     params ["_ctrlEdit"];
-    (_ctrlEdit getVariable QGVAR(params)) params ["_rowIndex", "_decimals"];
+    (_ctrlEdit getVariable QGVAR(params)) params ["_rowIndex", "_decimals", "_isPercentage"];
 
     private _value = parseNumber ctrlText _ctrlEdit;
 
-    if (_decimals < 0) then {
-        _value = round _value;
+    if (_isPercentage) then {
+        _value = _value / 100; // User will enter a percent from 0-100 not 0-1
+    } else {
+        if (_decimals < 0) then {
+            _value = round _value;
+        };
     };
 
     private _controlsGroup = ctrlParentControlsGroup _ctrlEdit;
@@ -75,16 +84,11 @@ _ctrlEdit ctrlAddEventHandler ["KeyUp", {
 
 _ctrlEdit ctrlAddEventHandler ["KillFocus", {
     params ["_ctrlEdit"];
-    (_ctrlEdit getVariable QGVAR(params)) params ["", "_decimals"];
+    (_ctrlEdit getVariable QGVAR(params)) params ["", "_decimals", "_isPercentage"];
 
     private _controlsGroup = ctrlParentControlsGroup _ctrlEdit;
     private _ctrlSlider = _controlsGroup controlsGroupCtrl IDC_ROW_SLIDER;
 
     private _value = sliderPosition _ctrlSlider;
-
-    if (_decimals < 0) then {
-        _value = round _value;
-    };
-
-    _ctrlEdit ctrlSetText ([_value, 1, _decimals max 0] call CBA_fnc_formatNumber);
+    _ctrlEdit ctrlSetText FORMAT_VALUE(_value,_decimals,_isPercentage);
 }];

--- a/addons/dialog/gui.hpp
+++ b/addons/dialog/gui.hpp
@@ -193,14 +193,14 @@ class GVAR(Row_Slider): GVAR(Row_Base) {
             idc = IDC_ROW_SLIDER;
             x = POS_W(10.1);
             y = 0;
-            w = POS_W(13.8);
+            w = POS_W(13.5);
             h = POS_H(1);
         };
         class Edit: GVAR(RscEdit) {
             idc = IDC_ROW_SLIDER_EDIT;
-            x = POS_W(24);
+            x = POS_W(23.7);
             y = pixelH;
-            w = POS_W(2);
+            w = POS_W(2.3);
             h = POS_H(1) - pixelH;
         };
     };

--- a/addons/garage/RscAttributes.hpp
+++ b/addons/garage/RscAttributes.hpp
@@ -1,7 +1,7 @@
 class EGVAR(attributes,RscAttributesBase);
 
 class EGVAR(attributes,RscAttributesVehicle): EGVAR(attributes,RscAttributesBase) {
-    class buttons {
+    class Buttons {
         class Garage {
             text = "$STR_A3_Garage";
             function = QFUNC(buttonGarage);
@@ -10,7 +10,7 @@ class EGVAR(attributes,RscAttributesVehicle): EGVAR(attributes,RscAttributesBase
 };
 
 class EGVAR(attributes,RscAttributesVehicleEmpty): EGVAR(attributes,RscAttributesBase) {
-    class buttons {
+    class Buttons {
         class Garage {
             text = "$STR_A3_Garage";
             function = QFUNC(buttonGarage);

--- a/addons/inventory/RscAttributes.hpp
+++ b/addons/inventory/RscAttributes.hpp
@@ -20,7 +20,7 @@ class EGVAR(attributes,RscAttributesBase) {
 };
 
 class EGVAR(attributes,RscAttributesVehicle): EGVAR(attributes,RscAttributesBase) {
-    class buttons {
+    class Buttons {
         class Inventory {
             text = "$STR_a3_gear1";
             function = QUOTE(createDialog QQEGVAR(attributes,RscAttributesInventory));
@@ -29,7 +29,7 @@ class EGVAR(attributes,RscAttributesVehicle): EGVAR(attributes,RscAttributesBase
 };
 
 class EGVAR(attributes,RscAttributesVehicleEmpty): EGVAR(attributes,RscAttributesBase) {
-    class buttons {
+    class Buttons {
         class Inventory {
             text = "$STR_a3_gear1";
             function = QUOTE(createDialog QQEGVAR(attributes,RscAttributesInventory));

--- a/docs/dynamic_dialog.md
+++ b/docs/dynamic_dialog.md
@@ -117,6 +117,10 @@ A side selection control with clickable icons for the BLUFOR, OPFOR, Independent
 
 A slider control with an attached edit box which can both be used to change the value.
 
+A percentage slider sub-type exists for this control type - `SLIDER:PERCENT`.
+When this sub-type is used, the value displayed in the edit box will be multiplied by 100 and be suffixed by a percent sign.
+The returned value will still be within the min and max values (ideally 0 to 1) and the decimals argument is not necessary.
+
 **Control Specific Argument(s):**
 
 - 0: Minimum value &lt;NUMBER&gt;


### PR DESCRIPTION
**When merged this pull request will:**
- Add skills button to unit and group attributes displays to allow for fine-tuning of AI sub-skills
- Add `SLIDER:PERCENT` sub-type to the slider dialog control
