### PR TITLE
Add multi-line edit box control types

### DIFF
--- a/addons/dialog/functions/fnc_create.sqf
+++ b/addons/dialog/functions/fnc_create.sqf
@@ -116,10 +116,22 @@ scopeName "Main";
             _controlType = QGVAR(Row_Combo);
         };
         case "EDIT": {
-            _valueInfo params [["_default", "", [""]], ["_fnc_sanitizeValue", {_this}, [{}]]];
-            _rowSettings append [_fnc_sanitizeValue];
+            _valueInfo params [["_default", "", [""]], ["_fnc_sanitizeValue", {_this}, [{}]], ["_height", 5, [0]]];
+
+            private _isMulti = _subType in ["MULTI", "CODE"];
+            _rowSettings append [_fnc_sanitizeValue, _isMulti, _height];
             _defaultValue = _default;
-            _controlType = QGVAR(Row_Edit);
+            _controlType = switch (_subType) do {
+                case "MULTI": {
+                    QGVAR(Row_EditMulti);
+                };
+                case "CODE": {
+                    QGVAR(Row_EditCode);
+                };
+                default {
+                    QGVAR(Row_Edit);
+                };
+            };
         };
         case "SIDES": {
             _defaultValue = _valueInfo param [0, nil, [west]];

--- a/addons/dialog/functions/fnc_gui_edit.sqf
+++ b/addons/dialog/functions/fnc_gui_edit.sqf
@@ -19,10 +19,19 @@
 #include "script_component.hpp"
 
 params ["_controlsGroup", "_rowIndex", "_currentValue", "_rowSettings"];
-_rowSettings params ["_fnc_sanitizeValue"];
+_rowSettings params ["_fnc_sanitizeValue", "_isMulti", "_height"];
 
 private _ctrlEdit = _controlsGroup controlsGroupCtrl IDC_ROW_EDIT;
 _ctrlEdit ctrlSetText _currentValue;
+
+// Adjust the height of multi-line edit boxes based on settings
+if (_isMulti) then {
+    _controlsGroup ctrlSetPositionH POS_H(_height + 1);
+    _controlsGroup ctrlCommit 0;
+
+    _ctrlEdit ctrlSetPositionH POS_H(_height);
+    _ctrlEdit ctrlCommit 0;
+};
 
 _ctrlEdit setVariable [QGVAR(params), [_rowIndex, _fnc_sanitizeValue]];
 

--- a/addons/dialog/gui.hpp
+++ b/addons/dialog/gui.hpp
@@ -128,6 +128,33 @@ class GVAR(Row_Edit): GVAR(Row_Base) {
     };
 };
 
+class GVAR(Row_EditMulti): GVAR(Row_Edit) {
+    class controls: controls {
+        class Name: Name {
+            x = 0;
+            w = POS_W(26);
+        };
+        class Edit: Edit {
+            style = ST_MULTI;
+            x = pixelW;
+            y = POS_H(1);
+            w = POS_W(26) - pixelW;
+            h = POS_H(5);
+        };
+    };
+};
+
+class GVAR(Row_EditCode): GVAR(Row_EditMulti) {
+    class controls: controls {
+        class Name: Name {};
+        class Edit: Edit {
+            font = "EtelkaMonospacePro";
+            sizeEx = POS_H(0.7);
+            autocomplete = "scripting";
+        };
+    };
+};
+
 class GVAR(Row_Combo): GVAR(Row_Base) {
     GVAR(script) = QFUNC(gui_combo);
     class controls: controls {

--- a/docs/dynamic_dialog.md
+++ b/docs/dynamic_dialog.md
@@ -91,10 +91,15 @@ The corresponding pretty names array can have elements in the following format, 
 A single line edit box with support for an optional sanitizing function.
 The function is called on every key press with the full text as an argument and its return value is the resulting text.
 
+Two multi-line edit box sub-types exist for this control type, `EDIT:MULTI` and `EDIT:CODE`.
+When either sub-type is used, an additional height argument can be supplied to change how tall the edit box is.
+The code sub-type provides scripting autocompletion to the user.
+
 **Control Specific Argument(s):**
 
 - 0: Default text &lt;STRING&gt;
 - 1: Sanitizing function &lt;CODE&gt;
+- 2: Height (only for multi-line types) &lt;NUMBER&gt;
 
 **Return Value:**
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add `EDIT:MULTI` and `EDIT:CODE` multi-line edit box sub-types to dialog
- Close #48 
