### PR TITLE
Keep context menu open if clicked action does nothing

### DIFF
--- a/addons/context_menu/functions/fnc_createContextGroup.sqf
+++ b/addons/context_menu/functions/fnc_createContextGroup.sqf
@@ -100,8 +100,11 @@ private _numberOfRows = 0;
 
             private _condition = _ctrlContextRow getVariable QGVAR(condition);
             private _statement = _ctrlContextRow getVariable QGVAR(statement);
-            SETUP_ACTION_VARS;
 
+            // Exit on empty statement, the menu should not close when the action does nothing
+            if (_statement isEqualTo {}) exitWith {};
+
+            SETUP_ACTION_VARS;
             if (ACTION_PARAMS call _condition) then {
                 ACTION_PARAMS call _statement;
             };


### PR DESCRIPTION
**When merged this pull request will:**
- Do not close the context menu when the user clicks an empty action
- Will help with actions that are only there to categorize others (stance, formation, etc.)
- This is the behaviour of the 3DEN context menu

