### PR TITLE
Add sensors button to attributes displays

### DIFF
--- a/addons/attributes/RscAttributes.hpp
+++ b/addons/attributes/RscAttributes.hpp
@@ -919,9 +919,9 @@ class GVAR(RscAttributesVehicle): GVAR(RscAttributesBase) {
         class ButtonCancel: ButtonCancel {};
     };
     class Buttons {
-        class Garage {
-            text = "$STR_A3_Garage";
-            function = QFUNC(buttonGarage);
+        class Sensors {
+            text = CSTRING(Sensors);
+            function = QFUNC(buttonSensors);
         };
     };
 };
@@ -949,9 +949,9 @@ class GVAR(RscAttributesVehicleEmpty): GVAR(RscAttributesBase) {
         class ButtonCancel: ButtonCancel {};
     };
     class Buttons {
-        class Garage {
-            text = "$STR_A3_Garage";
-            function = QFUNC(buttonGarage);
+        class Sensors {
+            text = CSTRING(Sensors);
+            function = QFUNC(buttonSensors);
         };
     };
 };

--- a/addons/attributes/XEH_PREP.hpp
+++ b/addons/attributes/XEH_PREP.hpp
@@ -21,6 +21,7 @@ PREP(attributeUnitPos);
 PREP(attributeWaypointTimeout);
 PREP(attributeWaypointType);
 PREP(buttonArsenal);
+PREP(buttonSensors);
 PREP(buttonSkills);
 PREP(getAttributeEntities);
 PREP(initAttributesDisplay);

--- a/addons/attributes/XEH_postInit.sqf
+++ b/addons/attributes/XEH_postInit.sqf
@@ -1,5 +1,15 @@
 #include "script_component.hpp"
 
+[QGVAR(setSensors), {
+    params ["_vehicle", "_sensors"];
+    _sensors params ["_radarMode", "_reportTargets", "_receiveTargets", "_reportPosition"];
+
+    _vehicle setVehicleRadar _radarMode;
+    _vehicle setVehicleReportRemoteTargets _reportTargets;
+    _vehicle setVehicleReceiveRemoteTargets _receiveTargets;
+    _vehicle setVehicleReportOwnPosition _reportPosition;
+}] call CBA_fnc_addEventHandler;
+
 [QGVAR(setSkills), {
     params ["_unit", "_skills"];
 

--- a/addons/attributes/functions/fnc_buttonSensors.sqf
+++ b/addons/attributes/functions/fnc_buttonSensors.sqf
@@ -1,0 +1,35 @@
+/*
+ * Author: mharis001
+ * Handles clicking the sensors button.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call zen_attributes_fnc_buttonSensors
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+private _vehicle = GETMVAR(BIS_fnc_initCuratorAttributes_target,objNull);
+
+["STR_3DEN_Object_AttributeCategory_VehicleSystems", [
+    ["COMBO", ["STR_3DEN_Object_Attribute_Radar_displayName", "STR_3DEN_Object_Attribute_Radar_tooltip"], [[], [
+        ["STR_3DEN_Attributes_Radar_Default_text", "STR_3DEN_Attributes_Radar_Default_tooltip"],
+        ["STR_3DEN_Attributes_Radar_RadarOn_text", "STR_3DEN_Attributes_Radar_RadarOn_tooltip"],
+        ["STR_3DEN_Attributes_Radar_RadarOff_text", "STR_3DEN_Attributes_Radar_RadarOff_tooltip"]
+    ], [2, 1] select isVehicleRadarOn _vehicle], true],
+    ["CHECKBOX", ["STR_3DEN_Object_Attribute_ReportRemoteTargets_displayName", "STR_3DEN_Object_Attribute_ReportRemoteTargets_tooltip"], vehicleReportRemoteTargets _vehicle, true],
+    ["CHECKBOX", ["STR_3DEN_Object_Attribute_ReceiveRemoteTargets_displayName", "STR_3DEN_Object_Attribute_ReceiveRemoteTargets_tooltip"], vehicleReceiveRemoteTargets _vehicle, true],
+    ["CHECKBOX", ["STR_3DEN_Object_Attribute_ReportOwnPosition_displayName", "STR_3DEN_Object_Attribute_ReportOwnPosition_tooltip"], vehicleReportOwnPosition _vehicle, true]
+], {
+    params ["_dialogValues", "_vehicle"];
+
+    {
+        [QGVAR(setSensors), [_x, _dialogValues], _x] call CBA_fnc_targetEvent;
+    } forEach (_vehicle call FUNC(getAttributeEntities));
+}, {}, _vehicle] call EFUNC(dialog,create);

--- a/addons/attributes/functions/fnc_buttonSkills.sqf
+++ b/addons/attributes/functions/fnc_buttonSkills.sqf
@@ -3,13 +3,13 @@
  * Handles clicking the skills button.
  *
  * Arguments:
- * 0: Button <CONTROL>
+ * None
  *
  * Return Value:
  * None
  *
  * Example:
- * [CONTROL] call zen_attributes_fnc_buttonSkills
+ * [] call zen_attributes_fnc_buttonSkills
  *
  * Public: No
  */

--- a/addons/attributes/stringtable.xml
+++ b/addons/attributes/stringtable.xml
@@ -31,6 +31,9 @@
             <German>Zeit (in Sekunden) zwischen der Erfüllung der Wegpunktbedingung und der Vervollständigung des Wegpunktes.</German>
             <Polish>Czas (w sekundach) pomiędzy wypełnieniem warunku zaliczenia punktu trasy a jego faktycznym zaliczeniem.</Polish>
         </Key>
+        <Key ID="STR_ZEN_Attributes_Sensors">
+            <English>Sensors</English>
+        </Key>
         <Key ID="STR_ZEN_Attributes_ChangeSkills">
             <English>Change Skills</English>
         </Key>


### PR DESCRIPTION
**When merged this pull request will:**
- Add sensors button to vehicle attributes displays to control vehicle data link capabilities