### PR TITLE
Disable attributes for JIP execute code module

### DIFF
--- a/addons/attributes/functions/fnc_bi_showCuratorAttributes.sqf
+++ b/addons/attributes/functions/fnc_bi_showCuratorAttributes.sqf
@@ -23,7 +23,7 @@ if (!isNull (missionNamespace getVariable ["bis_fnc_moduleRemoteControl_unit", o
 [_this] params [["_entity", objNull, [objNull, grpNull, [], ""]]];
 
 // Opening attributes disabled for object
-if (_entity isEqualType objNull && {_entity getVariable [QGVAR(disable), false]}) exitWith {};
+if (_entity isEqualType objNull && {_entity getVariable [QGVAR(disabled), false]}) exitWith {};
 
 private _curator = getAssignedCuratorLogic player;
 private _curatorInfoType = switch (typeName _entity) do {

--- a/addons/modules/functions/fnc_gui_cas.sqf
+++ b/addons/modules/functions/fnc_gui_cas.sqf
@@ -87,7 +87,7 @@ private _fnc_onConfirm = {
     _planeInfo params ["_planeClass", "_planeWeapons"];
 
     _logic setDir (missionNamespace getVariable [QGVAR(casDir), 0]);
-    _logic setVariable [QEGVAR(attributes,disable), true, true];
+    _logic setVariable [QEGVAR(attributes,disabled), true, true];
 
     [QGVAR(moduleCAS), [_logic, _casType, _planeClass, _planeWeapons]] call CBA_fnc_serverEvent;
 };

--- a/addons/modules/functions/fnc_gui_executeCode.sqf
+++ b/addons/modules/functions/fnc_gui_executeCode.sqf
@@ -24,10 +24,6 @@ params ["_display"];
 private _ctrlButtonOK = _display displayCtrl IDC_OK;
 private _logic = GETMVAR(BIS_fnc_initCuratorAttributes_target,objNull);
 
-if (_logic getVariable [QGVAR(executed), false]) exitWith {
-    _display closeDisplay 0;
-};
-
 if (!IS_ADMIN && {missionNamespace getVariable ["ZEN_disableCodeExecution", false]}) exitWith {
     [LSTRING(ModuleExecuteCode_Disabled)] call EFUNC(common,showMessage);
     deleteVehicle _logic;
@@ -114,7 +110,7 @@ private _fnc_onConfirm = {
     if (_delete) then {
         deleteVehicle _logic;
     } else {
-        _logic setVariable [QGVAR(executed), true, true];
+        _logic setVariable [QEGVAR(attributes,disabled), true, true];
     };
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Disable attributes display for execute code module when used in JIP mode
- Fix #64 
