### PR TITLE
Improve doors module hint when attached

### DIFF
--- a/addons/doors/functions/fnc_module.sqf
+++ b/addons/doors/functions/fnc_module.sqf
@@ -20,7 +20,7 @@ params ["_logic"];
 // Use attached building first then search nearby
 private _building = attachedTo _logic;
 
-if (isNull _building) then {
+if (isNull _building || {!(_building isKindOf "Building")}) then {
     _building = nearestObject [_logic, "Building"];
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- title, when attached to a non-building and a building is not nearby, displayed hint will be `NoBuilding` instead of `NoDoors`
- Also triggers nearby search when attached object is not a building