### PR TITLE
Use hovered entity for teleport Zeus

### DIFF
--- a/addons/context_actions/functions/fnc_teleportZeus.sqf
+++ b/addons/context_actions/functions/fnc_teleportZeus.sqf
@@ -4,13 +4,13 @@
  * Teleports Zeus to the given position or vehicle.
  *
  * Arguments:
- * 0: Position <ARRAY>
+ * None
  *
  * Return Value:
  * None
  *
  * Example:
- * [[0, 0, 0]] call zen_context_actions_fnc_teleportZeus
+ * [] call zen_context_actions_fnc_teleportZeus
  *
  * Public: No
  */

--- a/addons/context_actions/functions/fnc_teleportZeus.sqf
+++ b/addons/context_actions/functions/fnc_teleportZeus.sqf
@@ -15,12 +15,8 @@
  * Public: No
  */
 
-params ["_posASL"];
-
-curatorMouseOver params ["_type", "_entity"];
-
-if (_type isEqualTo "OBJECT" && {_entity isKindOf "AllVehicles"} && {!(_entity isKindOf "CAManBase")}) then {
-    [[player], _entity] call EFUNC(common,teleportIntoVehicle);
+if (_hoveredEntity isEqualType objNull && {_hoveredEntity isKindOf "AllVehicles"} && {!(_hoveredEntity isKindOf "CAManBase")}) then {
+    [[player], _hoveredEntity] call EFUNC(common,teleportIntoVehicle);
 } else {
-    player setPosASL _posASL;
+    player setPosASL _contextPosASL;
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Use `_hoveredEntity` instead of `curatorMouseOver` for Teleport Zeus action
- `curatorMouseOver` can change while `_hoveredEntity` will remain as the entity from when the menu was opened