### PR TITLE
Add Eject Passengers keybind

### DIFF
--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -5,6 +5,7 @@ PREP(createZeus);
 PREP(curatorDisplayLoad);
 PREP(curatorDisplayUnload);
 PREP(dumpPerformanceCounters);
+PREP(ejectPassengers);
 PREP(getActiveTree);
 PREP(getAllTurrets);
 PREP(getInventory);

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -86,6 +86,16 @@
     _unit doWatch _target;
 }] call CBA_fnc_addEventHandler;
 
+[QGVAR(moveInDriver), {
+    params ["_unit", "_vehicle"];
+    _unit moveInDriver _vehicle;
+}] call CBA_fnc_addEventHandler;
+
+[QGVAR(unassignVehicle), {
+    params ["_unit"];
+    unassignVehicle _unit;
+}] call CBA_fnc_addEventHandler;
+
 [QGVAR(setCaptive), {
     params ["_unit", "_status"];
     _unit setCaptive _status;

--- a/addons/common/functions/fnc_ejectPassengers.sqf
+++ b/addons/common/functions/fnc_ejectPassengers.sqf
@@ -1,0 +1,57 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Ejects passengers of the given vehicle one at a time.
+ * If the vehicle is flying, the units will be given parachutes.
+ *
+ * Arguments:
+ * 0: Vehicle <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [vehicle player] call zen_common_fnc_ejectPassengers
+ *
+ * Public: No
+ */
+
+#define PARACHUTE_HEIGHT 30
+#define PARACHUTE_DELAY 1.5
+#define PASSENGER_DELAY 1.2
+
+params ["_vehicle"];
+
+[{
+    params ["_vehicle", "_nextEject"];
+
+    // Only eject passengers (units assigned to "cargo" role)
+    private _passengers = crew _vehicle select {
+        alive _x && {assignedVehicleRole _x param [0, ""] == "cargo"}
+    };
+
+    // Small delay between each unit, all units do not immediately get out
+    if (CBA_missionTime >= _nextEject) then {
+        private _unit = _passengers deleteAt 0;
+        [QGVAR(unassignVehicle), _unit, _unit] call CBA_fnc_targetEvent;
+
+        // If the vehicle is currently high enough, create a parachute for the unit
+        if (ASLtoAGL getPosASL _vehicle select 2 > PARACHUTE_HEIGHT) then {
+            moveOut _unit;
+
+            [{
+                params ["_unit"];
+
+                private _parachute = createVehicle ["Steerable_Parachute_F", _unit, [], 0, "NONE"];
+                _parachute setDir getDir _unit;
+                _parachute setVelocity velocity _unit;
+
+                [QGVAR(moveInDriver), [_unit, _parachute], _unit] call CBA_fnc_targetEvent;
+            }, _unit, PARACHUTE_DELAY] call CBA_fnc_waitAndExecute;
+        };
+
+        _this set [1, CBA_missionTime + PASSENGER_DELAY];
+    };
+
+    !alive _vehicle || {_passengers isEqualTo []}
+}, {}, [_vehicle, CBA_missionTime]] call CBA_fnc_waitUntilAndExecute;

--- a/addons/editor/initKeybinds.sqf
+++ b/addons/editor/initKeybinds.sqf
@@ -4,3 +4,13 @@
         (findDisplay IDD_RSCDISPLAYCURATOR displayCtrl IDC_INCLUDE_CREW) cbSetChecked GVAR(includeCrew);
     };
 }, {}, [DIK_B, [false, false, false]]] call CBA_fnc_addKeybind; // Default: B
+
+[ELSTRING(common,Category), QGVAR(ejectPassengers), [LSTRING(EjectPassengers), LSTRING(EjectPassengers_Description)], {
+    if (!isNull curatorCamera) then {
+        {
+            [_x] call EFUNC(common,ejectPassengers);
+        } forEach SELECTED_OBJECTS;
+
+        true // handled, prevents vanilla eject from activating
+    };
+}, {}, [DIK_G, [false, true, false]]] call CBA_fnc_addKeybind; // Default: CTRL + G

--- a/addons/editor/stringtable.xml
+++ b/addons/editor/stringtable.xml
@@ -71,5 +71,11 @@
             <German>Besatzung hinzufügen umschalten</German>
             <Polish>Przełącz 'dołącz załogę'</Polish>
         </Key>
+        <Key ID="STR_ZEN_Editor_EjectPassengers">
+            <English>Eject Passengers</English>
+        </Key>
+        <Key ID="STR_ZEN_Editor_EjectPassengers_Description">
+            <English>Ejects the passengers of all selected vehicles. If the vehicle is currently flying, the units will be given parachutes.\nUnlike vanilla eject, units will disembark one after another (not immediately, with a short delay in-between).</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Add "Eject Passengers" keybind
- Unlike the vanilla eject keybind, only ejects cargo units and not immediately
- Units ejected from flying aircraft are given parachutes
