### PR TITLE
Fix custom modules category showing when curator addons are changed

### DIFF
--- a/addons/custom_modules/CfgFactionClasses.hpp
+++ b/addons/custom_modules/CfgFactionClasses.hpp
@@ -1,7 +1,0 @@
-class CfgFactionClasses {
-    class GVAR(category) {
-        displayName = QGVAR(category);
-        priority = 2;
-        side = 7;
-    };
-};

--- a/addons/custom_modules/CfgVehicles.hpp
+++ b/addons/custom_modules/CfgVehicles.hpp
@@ -4,9 +4,8 @@ class CfgVehicles {
     #define ADD_CUSTOM_MODULE(id) \
         class DOUBLES(GVAR(module),id): EGVAR(modules,moduleBase) { \
             displayName = CSTRING(DisplayName); \
-            category = QGVAR(category); \
             function = QFUNC(init); \
-            scopeCurator = 2; \
+            scopeCurator = 1; \
             GVAR(index) = __EVAL(id - 1); \
         }
 

--- a/addons/custom_modules/config.cpp
+++ b/addons/custom_modules/config.cpp
@@ -118,5 +118,4 @@ class CfgPatches {
 };
 
 #include "CfgEventHandlers.hpp"
-#include "CfgFactionClasses.hpp"
 #include "CfgVehicles.hpp"

--- a/addons/custom_modules/functions/fnc_addModules.sqf
+++ b/addons/custom_modules/functions/fnc_addModules.sqf
@@ -15,19 +15,12 @@
  * Public: No
  */
 
+if (isNil QGVAR(modulesList)) exitWith {};
+
 [{
     params ["_display"];
 
     private _ctrlTree = _display displayCtrl IDC_RSCDISPLAYCURATOR_CREATE_MODULES;
-
-    // Delete the custom modules category, needed to make recent tree work with custom modules
-    for "_i" from 0 to ((_ctrlTree tvCount []) - 1) do {
-        if (_ctrlTree tvText [_i] isEqualTo QGVAR(category)) exitWith {
-            _ctrlTree tvDelete [_i];
-        };
-    };
-
-    if (isNil QGVAR(modulesList)) exitWith {};
 
     if (isNil QGVAR(categories)) then {
         GVAR(categories) = [];


### PR DESCRIPTION
**When merged this pull request will:**
- title, when addons are changed while interface is open
- `scopeCurator` does  not need to be `2` for the modules to show up in recent tree, just need to be in `CfgPatches` units array