### PR TITLE
Add Area Markers

### DIFF
--- a/addons/area_markers/$PBOPREFIX$
+++ b/addons/area_markers/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\zen\addons\area_markers

--- a/addons/area_markers/CfgContext.hpp
+++ b/addons/area_markers/CfgContext.hpp
@@ -1,0 +1,9 @@
+class EGVAR(context_menu,actions) {
+    class ADDON {
+        displayName = CSTRING(CreateAreaMarker);
+        icon = ICON_MARKERS;
+        condition = QUOTE(visibleMap);
+        statement = QUOTE([ARR_2(QQGVAR(create),[_contextPosASL])] call CBA_fnc_serverEvent);
+        priority = -98;
+    };
+};

--- a/addons/area_markers/CfgEventHandlers.hpp
+++ b/addons/area_markers/CfgEventHandlers.hpp
@@ -1,0 +1,17 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+    };
+};
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
+    };
+};

--- a/addons/area_markers/CfgVehicles.hpp
+++ b/addons/area_markers/CfgVehicles.hpp
@@ -1,0 +1,10 @@
+class CfgVehicles {
+    class Module_F;
+    class EGVAR(modules,moduleBase);
+
+    class GVAR(module): EGVAR(modules,moduleBase) {
+        displayName = CSTRING(CreateAreaMarker);
+        function = QFUNC(module);
+        icon = ICON_MARKERS;
+    };
+};

--- a/addons/area_markers/XEH_PREP.hpp
+++ b/addons/area_markers/XEH_PREP.hpp
@@ -1,0 +1,13 @@
+PREP(applyProperties);
+PREP(configure);
+PREP(createIcon);
+PREP(deleteIcon);
+PREP(module);
+PREP(onKeyDown);
+PREP(onMouseButtonDown);
+PREP(onMouseButtonUp);
+PREP(onMouseDblClick);
+PREP(onMouseMoving);
+PREP(setIconAngle);
+PREP(setIconColor);
+PREP(update);

--- a/addons/area_markers/XEH_postInit.sqf
+++ b/addons/area_markers/XEH_postInit.sqf
@@ -1,0 +1,84 @@
+#include "script_component.hpp"
+
+if (isServer) then {
+    [QGVAR(create), {
+        params ["_position"];
+
+        private _marker = createMarker [format [QGVAR(%1), GVAR(nextID)], _position];
+        _marker setMarkerShape "RECTANGLE";
+        _marker setMarkerSize [50, 50];
+
+        GVAR(markers) pushBack _marker;
+        publicVariable QGVAR(markers);
+
+        GVAR(nextID) = GVAR(nextID) + 1;
+
+        [QGVAR(createIcon), _marker] call CBA_fnc_globalEvent;
+    }] call CBA_fnc_addEventHandler;
+
+    [QGVAR(delete), {
+        params ["_marker"];
+
+        private _index = GVAR(markers) find _marker;
+
+        if (_index != -1) then {
+            GVAR(markers) deleteAt _index;
+            publicVariable QGVAR(markers);
+
+            deleteMarker _marker;
+
+            [QGVAR(deleteIcon), _marker] call CBA_fnc_globalEvent;
+        };
+    }] call CBA_fnc_addEventHandler;
+};
+
+if (hasInterface) then {
+    ["ZEN_displayCuratorLoad", {
+        params ["_display"];
+
+        // Namespace of marker names and their corresponding icon controls
+        if (isNil QGVAR(icons)) then {
+            GVAR(icons) = [] call CBA_fnc_createNamespace;
+        };
+
+        // Add EH to update area marker icon positions when the map is shown
+        private _ctrlMap = _display displayCtrl IDC_RSCDISPLAYCURATOR_MAINMAP;
+        _ctrlMap ctrlAddEventHandler ["Draw", {call FUNC(update)}];
+
+        // Add EH to handle deleting area marker by pressing the DELETE key
+        _display displayAddEventHandler ["KeyDown", {call FUNC(onKeyDown)}];
+
+        // Create area marker icons for all area markers
+        {
+            {
+                [_x] call FUNC(createIcon);
+            } forEach GVAR(markers);
+        } call CBA_fnc_execNextFrame;
+
+        // Add PFH to update visibility of area marker icons
+        GVAR(visiblePFH) = [{
+            params ["_args"];
+            _args params ["_visible"];
+
+            if (_visible isEqualTo visibleMap) exitWith {};
+
+            _visible = visibleMap;
+            {
+                private _ctrlIcon = GVAR(icons) getVariable [_x, controlNull];
+                _ctrlIcon ctrlShow _visible;
+            } forEach GVAR(markers);
+
+            _args set [0, _visible];
+        }, 0, [visibleMap]] call CBA_fnc_addPerFrameHandler;
+    }] call CBA_fnc_addEventHandler;
+
+    ["ZEN_displayCuratorUnload", {
+        GVAR(visiblePFH) call CBA_fnc_removePerFrameHandler;
+    }] call CBA_fnc_addEventHandler;
+
+    [QGVAR(createIcon), LINKFUNC(createIcon)] call CBA_fnc_addEventHandler;
+    [QGVAR(deleteIcon), LINKFUNC(deleteIcon)] call CBA_fnc_addEventHandler;
+
+    [QGVAR(setIconAngle), LINKFUNC(setIconAngle)] call CBA_fnc_addEventHandler;
+    [QGVAR(setIconColor), LINKFUNC(setIconColor)] call CBA_fnc_addEventHandler;
+};

--- a/addons/area_markers/XEH_preInit.sqf
+++ b/addons/area_markers/XEH_preInit.sqf
@@ -1,0 +1,26 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+PREP_RECOMPILE_START;
+#include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
+
+if (isServer) then {
+    GVAR(markers) = [];
+    publicVariable QGVAR(markers);
+
+    GVAR(nextID) = 0;
+};
+
+if (hasInterface) then {
+    GVAR(colors) = [] call CBA_fnc_createNamespace;
+
+    {
+        if (getNumber (_x >> "scope") > 0) then {
+            GVAR(colors) setVariable [configName _x, (_x >> "color") call BIS_fnc_colorConfigToRGBA];
+        };
+    } forEach configProperties [configFile >> "CfgMarkerColors", "isClass _x"];
+};
+
+ADDON = true;

--- a/addons/area_markers/XEH_preStart.sqf
+++ b/addons/area_markers/XEH_preStart.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+#include "XEH_PREP.hpp"

--- a/addons/area_markers/config.cpp
+++ b/addons/area_markers/config.cpp
@@ -1,0 +1,22 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {
+            QGVAR(module)
+        };
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"zen_modules"};
+        author = ECSTRING(main,Author);
+        authors[] = {"mharis001"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgEventHandlers.hpp"
+#include "CfgVehicles.hpp"
+#include "CfgContext.hpp"
+#include "gui.hpp"

--- a/addons/area_markers/functions/fnc_applyProperties.sqf
+++ b/addons/area_markers/functions/fnc_applyProperties.sqf
@@ -1,0 +1,47 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Applies properties from the configure menu to the area marker.
+ *
+ * Arguments:
+ * 0: Configure Menu <CONTROL>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [CONTROL] call zen_area_markers_fnc_applyProperties
+ *
+ * Public: No
+ */
+
+params ["_ctrlConfigure"];
+
+private _marker = _ctrlConfigure getVariable [QGVAR(marker), ""];
+
+private _sizeA = parseNumber ctrlText (_ctrlConfigure controlsGroupCtrl IDC_CONFIGURE_SIZE_A);
+private _sizeB = parseNumber ctrlText (_ctrlConfigure controlsGroupCtrl IDC_CONFIGURE_SIZE_B);
+_marker setMarkerSize [_sizeA, _sizeB];
+
+private _ctrlRotationSlider = _ctrlConfigure controlsGroupCtrl IDC_CONFIGURE_ROTATION_SLIDER;
+private _rotation = sliderPosition _ctrlRotationSlider;
+_marker setMarkerDir _rotation;
+
+private _ctrlShape = _ctrlConfigure controlsGroupCtrl IDC_CONFIGURE_SHAPE;
+private _shape = ["RECTANGLE", "ELLIPSE"] select lbCurSel _ctrlShape;
+_marker setMarkerShape _shape;
+
+private _ctrlBrush = _ctrlConfigure controlsGroupCtrl IDC_CONFIGURE_BRUSH;
+private _brush = _ctrlBrush lbData lbCurSel _ctrlBrush;
+_marker setMarkerBrush _brush;
+
+private _ctrlColor = _ctrlConfigure controlsGroupCtrl IDC_CONFIGURE_COLOR;
+private _color = _ctrlColor lbData lbCurSel _ctrlColor;
+_marker setMarkerColor _color;
+
+private _ctrlAlphaSlider = _ctrlConfigure controlsGroupCtrl IDC_CONFIGURE_ALPHA_SLIDER;
+private _alpha = sliderPosition _ctrlAlphaSlider;
+_marker setMarkerAlpha _alpha;
+
+[QGVAR(setIconAngle), [_marker, _rotation]] call CBA_fnc_globalEvent;
+[QGVAR(setIconColor), [_marker, _color]] call CBA_fnc_globalEvent;

--- a/addons/area_markers/functions/fnc_configure.sqf
+++ b/addons/area_markers/functions/fnc_configure.sqf
@@ -15,8 +15,6 @@
  * Public: No
  */
 
-#define DEGREE_SYMBOL (toString [176])
-
 params ["_marker"];
 
 private _display = findDisplay IDD_RSCDISPLAYCURATOR;

--- a/addons/area_markers/functions/fnc_configure.sqf
+++ b/addons/area_markers/functions/fnc_configure.sqf
@@ -1,0 +1,193 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Opens a menu to configure the properties of the given area marker.
+ *
+ * Arguments:
+ * 0: Marker <STRING>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * ["marker_0"] call zen_area_markers_fnc_configure
+ *
+ * Public: No
+ */
+
+#define DEGREE_SYMBOL (toString [176])
+
+params ["_marker"];
+
+private _display = findDisplay IDD_RSCDISPLAYCURATOR;
+
+private _ctrlConfigure = _display ctrlCreate [QGVAR(configure), IDC_CONFIGURE_GROUP];
+ctrlSetFocus _ctrlConfigure;
+
+markerSize _marker params ["_sizeA", "_sizeB"];
+
+{
+    _x params ["_idc", "_value"];
+
+    private _ctrl = _ctrlConfigure controlsGroupCtrl _idc;
+    _ctrl ctrlSetText str _value;
+
+    _ctrl ctrlAddEventHandler ["KeyDown", {
+        params ["_ctrl"];
+
+        private _value  = ctrlText _ctrl;
+        private _filter = toArray ".-0123456789";
+        _value = toString (toArray _value select {_x in _filter});
+
+        _ctrl ctrlSetText _value;
+    }];
+} forEach [
+    [IDC_CONFIGURE_SIZE_A, _sizeA],
+    [IDC_CONFIGURE_SIZE_B, _sizeB]
+];
+
+private _ctrlRotationSlider = _ctrlConfigure controlsGroupCtrl IDC_CONFIGURE_ROTATION_SLIDER;
+private _ctrlRotationEdit   = _ctrlConfigure controlsGroupCtrl IDC_CONFIGURE_ROTATION_EDIT;
+[_ctrlRotationSlider, _ctrlRotationEdit, 0, 360, markerDir _marker, 15, {format ["%1%2", round _this, DEGREE_SYMBOL]}] call EFUNC(common,initSliderEdit);
+
+private _ctrlShape = _ctrlConfigure controlsGroupCtrl IDC_CONFIGURE_SHAPE;
+_ctrlShape lbSetCurSel (["RECTANGLE", "ELLIPSE"] find markerShape _marker);
+
+private _ctrlBrush = _ctrlConfigure controlsGroupCtrl IDC_CONFIGURE_BRUSH;
+private _markerBrush = markerBrush _marker;
+
+{
+    private _class = configName _x;
+    private _name  = getText (_x >> "name");
+    private _icon  = getText (_x >> "texture");
+
+    private _index = _ctrlBrush lbAdd _name;
+    _ctrlBrush lbSetData [_index, _class];
+    _ctrlBrush lbSetPicture [_index, _icon];
+
+    if (_class == _markerBrush) then {
+        _ctrlBrush lbSetCurSel _index;
+    };
+} forEach configProperties [configFile >> "CfgMarkerBrushes", "isClass _x"];
+
+private _ctrlColor = _ctrlConfigure controlsGroupCtrl IDC_CONFIGURE_COLOR;
+private _markerColor = markerColor _marker;
+
+{
+    if (getNumber (_x >> "scope") > 0) then {
+        private _class = configName _x;
+        private _name  = getText (_x >> "name");
+        private _color = (_x >> "color") call BIS_fnc_colorConfigToRGBA;
+
+        private _index = _ctrlColor lbAdd _name;
+        _ctrlColor lbSetData [_index, _class];
+        _ctrlColor lbSetPicture [_index, "#(argb,8,8,3)color(1,1,1,1)"];
+        _ctrlColor lbSetPictureColor [_index, _color];
+        _ctrlColor lbSetPictureColorSelected [_index, _color];
+
+        if (_class == _markerColor) then {
+            _ctrlColor lbSetCurSel _index;
+        };
+    };
+} forEach configProperties [configFile >> "CfgMarkerColors", "isClass _x"];
+
+private _ctrlAlphaSlider = _ctrlConfigure controlsGroupCtrl IDC_CONFIGURE_ALPHA_SLIDER;
+private _ctrlAlphaEdit   = _ctrlConfigure controlsGroupCtrl IDC_CONFIGURE_ALPHA_EDIT;
+[_ctrlAlphaSlider, _ctrlAlphaEdit, 0, 1, markerAlpha _marker, 0.1, 0, true] call EFUNC(common,initSliderEdit);
+
+private _ctrlButtonCancel = _ctrlConfigure controlsGroupCtrl IDC_CONFIGURE_CANCEL;
+_ctrlButtonCancel ctrlAddEventHandler ["ButtonClick", {
+    params ["_ctrlButtonCancel"];
+
+    private _display = ctrlParent _ctrlButtonCancel;
+    private _ctrlConfigure = _display displayCtrl IDC_CONFIGURE_GROUP;
+
+    private _keyDownEH = _ctrlConfigure getVariable [QGVAR(keyDownEH), -1];
+    _display displayRemoveEventHandler ["KeyDown", _keyDownEH];
+
+    ctrlDelete _ctrlConfigure;
+}];
+
+private _ctrlButtonOK = _ctrlConfigure controlsGroupCtrl IDC_CONFIGURE_OK;
+_ctrlButtonOK ctrlAddEventHandler ["ButtonClick", {
+    params ["_ctrlButtonOK"];
+
+    private _display = ctrlParent _ctrlButtonOK;
+    private _ctrlConfigure = _display displayCtrl IDC_CONFIGURE_GROUP;
+
+    private _keyDownEH = _ctrlConfigure getVariable [QGVAR(keyDownEH), -1];
+    _display displayRemoveEventHandler ["KeyDown", _keyDownEH];
+
+    [_ctrlConfigure] call FUNC(applyProperties);
+
+    ctrlDelete _ctrlConfigure;
+}];
+
+// Special handling for keyboard input when edit boxes have focus
+// Needed to prevent interaction with Zeus display but still allow keyboard use with edit boxes
+{
+    private _ctrl = _ctrlConfigure controlsGroupCtrl _x;
+
+    _ctrl ctrlAddEventHandler ["SetFocus", {
+        params ["_ctrl"];
+
+        private _ctrlConfigure = ctrlParent _ctrl displayCtrl IDC_CONFIGURE_GROUP;
+        _ctrlConfigure setVariable [QGVAR(focus), _ctrl];
+    }];
+
+    _ctrl ctrlAddEventHandler ["SetFocus", {
+        params ["_ctrl"];
+
+        private _ctrlConfigure = ctrlParent _ctrl displayCtrl IDC_CONFIGURE_GROUP;
+        _ctrlConfigure setVariable [QGVAR(focus), nil];
+    }];
+} forEach [
+    IDC_CONFIGURE_SIZE_A,
+    IDC_CONFIGURE_SIZE_B,
+    IDC_CONFIGURE_ROTATION_EDIT,
+    IDC_CONFIGURE_ALPHA_EDIT
+];
+
+private _keyDownEH = _display displayAddEventHandler ["KeyDown", {
+    call {
+        params ["_display", "_keyCode"];
+
+        if (_keyCode in [DIK_UP, DIK_DOWN, DIK_LEFT, DIK_RIGHT]) exitWith {false};
+
+        if (_keyCode in [DIK_BACKSPACE, DIK_DELETE]) then {
+            private _ctrlConfigure = _display displayCtrl IDC_CONFIGURE_GROUP;
+            private _ctrlEdit = _ctrlConfigure getVariable QGVAR(focus);
+            if (isNil "_ctrlEdit") exitWith {};
+
+            private _text = ctrlText _ctrlEdit;
+
+            if (_keyCode == DIK_BACKSPACE) then {
+                _text = _text select [0, count _text - 1];
+            };
+
+            if (_keyCode == DIK_DELETE) then {
+                _text = _text select [1, count _text - 1];
+            };
+
+            _ctrlEdit ctrlSetText _text;
+        };
+
+        if (_keyCode in [DIK_ESCAPE, DIK_RETURN]) then {
+            private _ctrlConfigure = _display displayCtrl IDC_CONFIGURE_GROUP;
+
+            if (_keyCode == DIK_RETURN) then {
+                [_ctrlConfigure] call FUNC(applyProperties);
+            };
+
+            private _keyDownEH = _ctrlConfigure getVariable [QGVAR(keyDownEH), -1];
+            _display displayRemoveEventHandler ["KeyDown", _keyDownEH];
+
+            ctrlDelete _ctrlConfigure;
+        };
+
+        true // handled
+    };
+}];
+
+_ctrlConfigure setVariable [QGVAR(keyDownEH), _keyDownEH];
+_ctrlConfigure setVariable [QGVAR(marker), _marker];

--- a/addons/area_markers/functions/fnc_createIcon.sqf
+++ b/addons/area_markers/functions/fnc_createIcon.sqf
@@ -1,0 +1,30 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Creates an icon control for the given area marker.
+ *
+ * Arguments:
+ * 0: Marker <STRING>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * ["marker_0"] call zen_area_markers_fnc_createIcon
+ *
+ * Public: No
+ */
+
+params ["_marker"];
+
+private _display = findDisplay IDD_RSCDISPLAYCURATOR;
+if (isNull _display) exitWith {};
+
+private _ctrlIcon = _display ctrlCreate [QGVAR(icon), IDC_ICON_GROUP];
+_ctrlIcon setVariable [QGVAR(marker), _marker];
+_ctrlIcon ctrlShow visibleMap;
+
+GVAR(icons) setVariable [_marker, _ctrlIcon];
+
+[_marker, markerDir _marker] call FUNC(setIconAngle);
+[_marker, markerColor _marker] call FUNC(setIconColor);

--- a/addons/area_markers/functions/fnc_deleteIcon.sqf
+++ b/addons/area_markers/functions/fnc_deleteIcon.sqf
@@ -1,0 +1,25 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Deletes the icon control of the given area marker.
+ *
+ * Arguments:
+ * 0: Marker <STRING>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * ["marker_0"] call zen_area_markers_fnc_deleteIcon
+ *
+ * Public: No
+ */
+
+params ["_marker"];
+
+private _ctrlIcon = GVAR(icons) getVariable _marker;
+if (isNil "_ctrlIcon" || {isNull _ctrlIcon}) exitWith {};
+
+GVAR(icons) setVariable [_marker, nil];
+
+ctrlDelete _ctrlIcon;

--- a/addons/area_markers/functions/fnc_module.sqf
+++ b/addons/area_markers/functions/fnc_module.sqf
@@ -1,0 +1,29 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Zeus module function to create an area marker.
+ *
+ * Arguments:
+ * 0: Logic <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [LOGIC] call zen_area_markers_fnc_module
+ *
+ * Public: No
+ */
+
+params ["_logic"];
+
+deleteVehicle _logic;
+
+if (!visibleMap) exitWith {
+    [LSTRING(PlaceOnMap)] call EFUNC(common,showMessage);
+};
+
+private _ctrlMap = findDisplay IDD_RSCDISPLAYCURATOR displayCtrl IDC_RSCDISPLAYCURATOR_MAINMAP;
+private _position = _ctrlMap ctrlMapScreenToWorld getMousePosition;
+
+[QGVAR(create), [_position]] call CBA_fnc_serverEvent;

--- a/addons/area_markers/functions/fnc_onKeyDown.sqf
+++ b/addons/area_markers/functions/fnc_onKeyDown.sqf
@@ -1,0 +1,33 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles keyboard input for the Zeus display.
+ *
+ * Arguments:
+ * 0: Display <DISPLAY>
+ * 1: Key Code <NUMBER>
+ *
+ * Return Value:
+ * Handled <BOOL>
+ *
+ * Example:
+ * [DISPLAY, 0] call zen_markers_tree_fnc_keyDown
+ *
+ * Public: No
+ */
+
+params ["_display", "_keyCode"];
+
+if (visibleMap && {_keyCode == DIK_DELETE}) exitWith {
+    private _ctrlMap = _display displayCtrl IDC_RSCDISPLAYCURATOR_MAINMAP;
+    ctrlMapMouseOver _ctrlMap params [["_type", ""], ["_marker", ""]];
+
+    if (_type == "marker" && {_marker in GVAR(markers)}) exitWith {
+        [QGVAR(delete), _marker] call CBA_fnc_serverEvent;
+        true
+    };
+
+    false
+};
+
+false

--- a/addons/area_markers/functions/fnc_onMouseButtonDown.sqf
+++ b/addons/area_markers/functions/fnc_onMouseButtonDown.sqf
@@ -1,0 +1,23 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles pressing a mouse button on an area marker icon.
+ *
+ * Arguments:
+ * 0: Mouse Area <CONTROL>
+ * 1: Button <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [CONTROL, 0] call zen_area_markers_fnc_onMouseButtonDown
+ *
+ * Public: No
+ */
+
+params ["_ctrlMouse", "_button"];
+
+if (_button == 0) then {
+    _ctrlMouse setVariable [QGVAR(moving), true];
+};

--- a/addons/area_markers/functions/fnc_onMouseButtonUp.sqf
+++ b/addons/area_markers/functions/fnc_onMouseButtonUp.sqf
@@ -1,0 +1,27 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles releasing a mouse button on an area marker icon.
+ *
+ * Arguments:
+ * 0: Mouse Area <CONTROL>
+ * 1: Button <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [CONTROL, 0] call zen_area_markers_fnc_onMouseButtonUp
+ *
+ * Public: No
+ */
+
+params ["_ctrlMouse", "_button"];
+
+if (_button == 0) then {
+    // Update position globally to the current local position once moving is finished
+    private _marker = ctrlParentControlsGroup _ctrlMouse getVariable [QGVAR(marker), ""];
+    _marker setMarkerPos markerPos _marker;
+
+    _ctrlMouse setVariable [QGVAR(moving), false];
+};

--- a/addons/area_markers/functions/fnc_onMouseDblClick.sqf
+++ b/addons/area_markers/functions/fnc_onMouseDblClick.sqf
@@ -1,0 +1,24 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles double clicking a mouse button on an area marker icon.
+ *
+ * Arguments:
+ * 0: Mouse Area <CONTROL>
+ * 1: Button <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [CONTROL, 0] call zen_area_markers_fnc_onMouseDblClick
+ *
+ * Public: No
+ */
+
+params ["_ctrlMouse", "_button"];
+
+if (_button == 0) then {
+    private _marker = ctrlParentControlsGroup _ctrlMouse getVariable [QGVAR(marker), ""];
+    [_marker] call FUNC(configure);
+};

--- a/addons/area_markers/functions/fnc_onMouseMoving.sqf
+++ b/addons/area_markers/functions/fnc_onMouseMoving.sqf
@@ -1,0 +1,25 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles moving the mouse on an area marker icon.
+ *
+ * Arguments:
+ * 0: Mouse Area <CONTROL>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [CONTROL] call zen_area_markers_fnc_onMouseMoving
+ *
+ * Public: No
+ */
+
+params ["_ctrlMouse"];
+
+if (_ctrlMouse getVariable [QGVAR(moving), false]) then {
+    private _ctrlMap = ctrlParent _ctrlMouse displayCtrl IDC_RSCDISPLAYCURATOR_MAINMAP;
+
+    private _marker = ctrlParentControlsGroup _ctrlMouse getVariable [QGVAR(marker), ""];
+    _marker setMarkerPosLocal (_ctrlMap ctrlMapScreenToWorld getMousePosition);
+};

--- a/addons/area_markers/functions/fnc_setIconAngle.sqf
+++ b/addons/area_markers/functions/fnc_setIconAngle.sqf
@@ -1,0 +1,24 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Sets the angle of the given area marker's icon control.
+ *
+ * Arguments:
+ * 0: Marker <STRING>
+ * 1: Angle <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * ["marker_0", 45] call zen_area_markers_setIconAngle
+ *
+ * Public: No
+ */
+
+params ["_marker", "_angle"];
+
+private _ctrlIcon = GVAR(icons) getVariable _marker;
+if (isNil "_ctrlIcon" || {isNull _ctrlIcon}) exitWith {};
+
+_ctrlIcon ctrlSetAngle [_angle, 0.5, 0.5];

--- a/addons/area_markers/functions/fnc_setIconColor.sqf
+++ b/addons/area_markers/functions/fnc_setIconColor.sqf
@@ -1,0 +1,25 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Sets the color of the given area marker's icon control.
+ *
+ * Arguments:
+ * 0: Marker <STRING>
+ * 1: Color <STRING>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * ["marker_0", "ColorRed"] call zen_area_markers_setIconColor
+ *
+ * Public: No
+ */
+
+params ["_marker", "_color"];
+
+private _ctrlIcon = GVAR(icons) getVariable _marker;
+if (isNil "_ctrlIcon" || {isNull _ctrlIcon}) exitWith {};
+
+private _ctrlImage = _ctrlIcon controlsGroupCtrl IDC_ICON_IMAGE;
+_ctrlImage ctrlSetTextColor (GVAR(colors) getVariable [_color, [0, 0, 0, 1]]);

--- a/addons/area_markers/functions/fnc_update.sqf
+++ b/addons/area_markers/functions/fnc_update.sqf
@@ -1,0 +1,33 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles updating the positions of area marker icons.
+ *
+ * Arguments:
+ * 0: Map <CONTROL>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [CONTROL] call zen_area_markers_fnc_update
+ *
+ * Public: No
+ */
+
+BEGIN_COUNTER(update);
+
+params ["_ctrlMap"];
+
+{
+    private _ctrlIcon = GVAR(icons) getVariable _x;
+
+    if (!isNil "_ctrlIcon") then {
+        (_ctrlMap ctrlMapWorldToScreen markerPos _x) params ["_posX", "_posY"];
+
+        _ctrlIcon ctrlSetPosition [_posX - OFFSET_X, _posY - OFFSET_Y];
+        _ctrlIcon ctrlCommit 0;
+    };
+} forEach GVAR(markers);
+
+END_COUNTER(update);

--- a/addons/area_markers/functions/script_component.hpp
+++ b/addons/area_markers/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "\x\zen\addons\area_markers\script_component.hpp"

--- a/addons/area_markers/gui.hpp
+++ b/addons/area_markers/gui.hpp
@@ -1,0 +1,252 @@
+class RscText;
+class RscPicture;
+class ctrlXSliderH;
+class RscButtonMenuOK;
+class RscButtonMenuCancel;
+class ctrlToolboxPictureKeepAspect;
+class RscControlsGroupNoScrollbars;
+
+class EGVAR(attributes,RscLabel);
+class EGVAR(attributes,RscBackground);
+class EGVAR(attributes,RscEdit);
+class EGVAR(attributes,RscCombo);
+
+class GVAR(icon): RscControlsGroupNoScrollbars {
+    idc = IDC_ICON_GROUP;
+    x = 0;
+    y = 0;
+    w = ICON_WIDTH;
+    h = ICON_HEIGHT;
+    class controls {
+        class Icon: RscPicture {
+            idc = IDC_ICON_IMAGE;
+            text = ICON_CENTER;
+            x = 0;
+            y = 0;
+            w = ICON_WIDTH;
+            h = ICON_HEIGHT;
+        };
+        class Mouse: RscText {
+            idc = IDC_ICON_MOUSE;
+            style = ST_MULTI;
+            onMouseButtonDblClick = QUOTE(call FUNC(onMouseDblClick));
+            onMouseButtonDown = QUOTE(call FUNC(onMouseButtonDown));
+            onMouseButtonUp = QUOTE(call FUNC(onMouseButtonUp));
+            onMouseMoving = QUOTE(call FUNC(onMouseMoving));
+            x = 0;
+            y = 0;
+            w = ICON_WIDTH;
+            h = ICON_HEIGHT;
+        };
+    };
+};
+
+class GVAR(configure): RscControlsGroupNoScrollbars {
+    idc = IDC_CONFIGURE_GROUP;
+    x = safeZoneXAbs;
+    y = safeZoneY;
+    w = safeZoneWAbs;
+    h = safeZoneH;
+    class controls {
+        class Container: RscControlsGroupNoScrollbars {
+            idc = -1;
+            x = safeZoneWAbs / 2 - POS_W(13.5);
+            y = safeZoneH / 2 - POS_H(6.5);
+            w = POS_W(27);
+            h = POS_H(13);
+            class controls {
+                class Title: RscText {
+                    text = CSTRING(EditAreaMarker);
+                    x = 0;
+                    y = 0;
+                    w = POS_W(27);
+                    h = POS_H(1);
+                    colorBackground[] = GUI_THEME_COLOR;
+                };
+                class Background: RscText {
+                    idc = -1;
+                    x = 0;
+                    y = POS_H(1.1);
+                    w = POS_W(27);
+                    h = POS_H(10.8);
+                    colorBackground[] = {0, 0, 0, 0.7};
+                };
+                class Transformation: RscControlsGroupNoScrollbars {
+                    idc = -1;
+                    x = POS_W(0.5);
+                    y = POS_H(1.6);
+                    w = POS_W(26);
+                    h = POS_H(3.3);
+                    class controls {
+                        class Title: EGVAR(attributes,RscLabel) {
+                            text = "$STR_3DEN_Object_AttributeCategory_Transformation";
+                            w = POS_W(26);
+                        };
+                        class Background: EGVAR(attributes,RscBackground) {
+                            x = 0;
+                            y = POS_H(1);
+                            w = POS_W(26);
+                            h = POS_H(2.3);
+                        };
+                        class SizeLabel: EGVAR(attributes,RscLabel) {
+                            text = "$STR_3DEN_Trigger_Attribute_Size_displayName";
+                            tooltip = "$STR_3DEN_Trigger_Attribute_Size_tooltip";
+                            x = POS_W(3);
+                            y = POS_H(1.1);
+                            w = POS_W(8.9);
+                            colorBackground[] = {0, 0, 0, 0.7};
+                        };
+                        class IconA: RscText {
+                            idc = -1;
+                            style = ST_CENTER;
+                            text = "$STR_3DEN_Axis_A";
+                            x = POS_W(12);
+                            y = POS_H(1.1);
+                            w = POS_W(1);
+                            h = POS_H(1);
+                            font = "RobotoCondensedLight";
+                            colorBackground[] = {0.77, 0.18, 0.1, 1};
+                            shadow = 0;
+                        };
+                        class EditA: EGVAR(attributes,RscEdit) {
+                            idc = IDC_CONFIGURE_SIZE_A;
+                            x = POS_W(13.1);
+                            y = POS_H(1.1) + pixelH;
+                            w = POS_W(4.35);
+                            h = POS_H(1) - pixelH;
+                            colorBackground[] = {0, 0, 0, 0.4};
+                        };
+                        class IconB: IconA {
+                            text = "$STR_3DEN_Axis_B";
+                            x = POS_W(17.55);
+                            colorBackground[] = {0.58, 0.82, 0.22, 1};
+                        };
+                        class EditB: EditA {
+                            idc = IDC_CONFIGURE_SIZE_B;
+                            x = POS_W(18.65);
+                        };
+                        class RotationLabel: SizeLabel {
+                            text = "$STR_3DEN_Object_Attribute_Rotation_displayName";
+                            tooltip = "";
+                            y = POS_H(2.2);
+                        };
+                        class RotationSlider: ctrlXSliderH {
+                            idc = IDC_CONFIGURE_ROTATION_SLIDER;
+                            x = POS_W(12);
+                            y = POS_H(2.2);
+                            w = POS_W(8.7);
+                            h = POS_H(1);
+                        };
+                        class RotationEdit: EGVAR(attributes,RscEdit) {
+                            idc = IDC_CONFIGURE_ROTATION_EDIT;
+                            x = POS_W(20.8);
+                            y = POS_H(2.2) + pixelH;
+                            w = POS_W(2.2);
+                            colorBackground[] = {0, 0, 0, 0.4};
+                        };
+                    };
+                };
+                class Style: RscControlsGroupNoScrollbars {
+                    idc = -1;
+                    x = POS_W(0.5);
+                    y = POS_H(5);
+                    w = POS_W(26);
+                    h = POS_H(6.5);
+                    class controls {
+                        class Title: EGVAR(attributes,RscLabel) {
+                            text = "$STR_3DEN_Marker_AttributeCategory_Style";
+                            w = POS_W(26);
+                        };
+                        class Background: EGVAR(attributes,RscBackground) {
+                            x = 0;
+                            y = POS_H(1);
+                            w = POS_W(26);
+                            h = POS_H(5.5);
+                        };
+                        class ShapeLabel: EGVAR(attributes,RscLabel) {
+                            text = "$STR_3DEN_Trigger_Attribute_Shape_displayName";
+                            tooltip = "$STR_3DEN_Trigger_Attribute_Shape_tooltip";
+                            x = POS_W(3);
+                            y = POS_H(1.1);
+                            w = POS_W(8.9);
+                            h = POS_H(2);
+                            colorBackground[] = {0, 0, 0, 0.7};
+                        };
+                        class Shape: ctrlToolboxPictureKeepAspect {
+                            idc = IDC_CONFIGURE_SHAPE;
+                            x = POS_W(12);
+                            y = POS_H(1.1);
+                            w = POS_W(11);
+                            h = POS_H(2);
+                            colorBackground[] = {0, 0, 0, 0.7};
+                            rows = 1;
+                            columns = 2;
+                            strings[] = {
+                                "\a3\3DEN\Data\Attributes\Shape\rectangle_ca.paa",
+                                "\a3\3DEN\Data\Attributes\Shape\ellipse_ca.paa"
+                            };
+                            tooltips[] = {
+                                "$STR_3den_attributes_shapetrigger_rectangle",
+                                "$STR_3den_attributes_shapetrigger_ellipse"
+                            };
+                        };
+                        class BrushLabel: ShapeLabel {
+                            text = "$STR_3DEN_Marker_Attribute_Brush_displayName";
+                            tooltip = "$STR_3DEN_Marker_Attribute_Brush_tooltip";
+                            y = POS_H(3.2);
+                            h = POS_H(1);
+                        };
+                        class Brush: EGVAR(attributes,RscCombo) {
+                            idc = IDC_CONFIGURE_BRUSH;
+                            x = POS_W(12);
+                            y = POS_H(3.2);
+                            w = POS_W(11);
+                        };
+                        class ColorLabel: BrushLabel {
+                            text = "$STR_3DEN_Marker_Attribute_Color_displayName";
+                            tooltip = "$STR_3DEN_Marker_Attribute_Color_tooltip";
+                            y = POS_H(4.3);
+                        };
+                        class Color: Brush {
+                            idc = IDC_CONFIGURE_COLOR;
+                            y = POS_H(4.3);
+                        };
+                        class AlphaLabel: BrushLabel {
+                            text = "$STR_3DEN_Marker_Attribute_Alpha_displayName";
+                            tooltip = "";
+                            y = POS_H(5.4);
+                        };
+                        class AlphaSlider: ctrlXSliderH {
+                            idc = IDC_CONFIGURE_ALPHA_SLIDER;
+                            x = POS_W(12);
+                            y = POS_H(5.4);
+                            w = POS_W(8.7);
+                            h = POS_H(1);
+                        };
+                        class AlphaEdit: EGVAR(attributes,RscEdit) {
+                            idc = IDC_CONFIGURE_ALPHA_EDIT;
+                            x = POS_W(20.8);
+                            y = POS_H(5.4) + pixelH;
+                            w = POS_W(2.2);
+                            colorBackground[] = {0, 0, 0, 0.4};
+                        };
+                    };
+                };
+                class ButtonOK: RscButtonMenuOK {
+                    idc = IDC_CONFIGURE_OK;
+                    x = POS_W(22);
+                    y = POS_H(12);
+                    w = POS_W(5);
+                    h = POS_H(1);
+                };
+                class ButtonCancel: RscButtonMenuCancel {
+                    idc = IDC_CONFIGURE_CANCEL;
+                    x = 0;
+                    y = POS_H(12);
+                    w = POS_W(5);
+                    h = POS_H(1);
+                };
+            };
+        };
+    };
+};

--- a/addons/area_markers/script_component.hpp
+++ b/addons/area_markers/script_component.hpp
@@ -1,0 +1,56 @@
+#define COMPONENT area_markers
+#define COMPONENT_BEAUTIFIED Area Markers
+#include "\x\zen\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_AREA_MARKERS
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_AREA_MARKERS
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_AREA_MARKERS
+#endif
+
+#include "\x\zen\addons\main\script_macros.hpp"
+
+#include "\a3\ui_f\hpp\defineDIKCodes.inc"
+#include "\a3\ui_f\hpp\defineCommonGrids.inc"
+#include "\x\zen\addons\common\defineResinclDesign.inc"
+
+#define POS_X(N) ((N) * GUI_GRID_W + GUI_GRID_CENTER_X)
+#define POS_Y(N) ((N) * GUI_GRID_H + GUI_GRID_CENTER_Y)
+#define POS_W(N) ((N) * GUI_GRID_W)
+#define POS_H(N) ((N) * GUI_GRID_H)
+
+#define ICON_SIZE 0.6
+
+#define ICON_WIDTH  POS_W(ICON_SIZE)
+#define ICON_HEIGHT POS_H(ICON_SIZE)
+
+#define OFFSET_X POS_W(ICON_SIZE / 2)
+#define OFFSET_Y POS_H(ICON_SIZE / 2)
+
+#define ICON_CENTER "\a3\3den\data\cfg3den\marker\texturecenter_ca.paa"
+#define ICON_MARKERS "\a3\3den\data\displays\display3den\panelright\submode_marker_area_ca.paa"
+#define ICON_ELLIPSE "\a3\3DEN\Data\Attributes\Shape\ellipse_ca.paa"
+#define ICON_RECTANGLE "\a3\3DEN\Data\Attributes\Shape\rectangle_ca.paa"
+
+#define IDC_ICON_GROUP 85800
+#define IDC_ICON_IMAGE 85810
+#define IDC_ICON_MOUSE 85820
+
+#define IDC_CONFIGURE_GROUP 42870
+#define IDC_CONFIGURE_SIZE_A 42871
+#define IDC_CONFIGURE_SIZE_B 42872
+#define IDC_CONFIGURE_ROTATION_SLIDER 42873
+#define IDC_CONFIGURE_ROTATION_EDIT 42874
+#define IDC_CONFIGURE_SHAPE 42875
+#define IDC_CONFIGURE_BRUSH 42876
+#define IDC_CONFIGURE_COLOR 42877
+#define IDC_CONFIGURE_ALPHA_SLIDER 42878
+#define IDC_CONFIGURE_ALPHA_EDIT 42879
+#define IDC_CONFIGURE_OK 42880
+#define IDC_CONFIGURE_CANCEL  428781

--- a/addons/area_markers/stringtable.xml
+++ b/addons/area_markers/stringtable.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="ZEN">
+    <Package name="Area_Markers">
+        <Key ID="STR_ZEN_Area_Markers_CreateAreaMarker">
+            <English>Create Area Marker</English>
+        </Key>
+        <Key ID="STR_ZEN_Area_Markers_EditAreaMarker">
+            <English>EDIT AREA MARKER</English>
+        </Key>
+        <Key ID="STR_ZEN_Area_Markers_PlaceOnMap">
+            <English>Place On Map</English>
+        </Key>
+    </Package>
+</Project>

--- a/addons/common/functions/fnc_initSliderEdit.sqf
+++ b/addons/common/functions/fnc_initSliderEdit.sqf
@@ -33,7 +33,7 @@
 
 params ["_ctrlSlider", "_ctrlEdit", "_min", "_max", "_value", "_speed", ["_formatting", 0, [0, {}]], ["_isPercentage", false, [false]]];
 
-private _fnc_getFormattedValue = {
+private _fnc_formatValue = {
     if (_isPercentage) then {
         format [localize "STR_3DEN_percentageUnit", round (_value * 100), "%"];
     } else {
@@ -48,17 +48,17 @@ private _fnc_getFormattedValue = {
 _ctrlSlider sliderSetRange [_min, _max];
 _ctrlSlider sliderSetSpeed [_speed, _speed];
 _ctrlSlider sliderSetPosition _value;
-_ctrlSlider setVariable [QGVAR(params), [_ctrlEdit, _formatting, _isPercentage, _fnc_getFormattedValue]];
+_ctrlSlider setVariable [QGVAR(params), [_ctrlEdit, _formatting, _isPercentage, _fnc_formatValue]];
 
 _ctrlSlider ctrlAddEventHandler ["SliderPosChanged", {
     params ["_ctrlSlider", "_value"];
-    (_ctrlSlider getVariable QGVAR(params)) params ["_ctrlEdit", "_formatting", "_isPercentage", "_fnc_getFormattedValue"];
+    (_ctrlSlider getVariable QGVAR(params)) params ["_ctrlEdit", "_formatting", "_isPercentage", "_fnc_formatValue"];
 
-    _ctrlEdit ctrlSetText call _fnc_getFormattedValue;
+    _ctrlEdit ctrlSetText call _fnc_formatValue;
 }];
 
-_ctrlEdit ctrlSetText call _fnc_getFormattedValue;
-_ctrlEdit setVariable [QGVAR(params), [_ctrlSlider, _formatting, _isPercentage, _fnc_getFormattedValue]];
+_ctrlEdit ctrlSetText call _fnc_formatValue;
+_ctrlEdit setVariable [QGVAR(params), [_ctrlSlider, _formatting, _isPercentage, _fnc_formatValue]];
 
 _ctrlEdit ctrlAddEventHandler ["KeyUp", {
     params ["_ctrlEdit"];
@@ -75,8 +75,8 @@ _ctrlEdit ctrlAddEventHandler ["KeyUp", {
 
 _ctrlEdit ctrlAddEventHandler ["KillFocus", {
     params ["_ctrlEdit"];
-    (_ctrlEdit getVariable QGVAR(params)) params ["_ctrlSlider", "_formatting", "_isPercentage", "_fnc_getFormattedValue"];
+    (_ctrlEdit getVariable QGVAR(params)) params ["_ctrlSlider", "_formatting", "_isPercentage", "_fnc_formatValue"];
 
     private _value = sliderPosition _ctrlSlider;
-    _ctrlEdit ctrlSetText call _fnc_getFormattedValue;
+    _ctrlEdit ctrlSetText call _fnc_formatValue;
 }];

--- a/addons/common/functions/fnc_initSliderEdit.sqf
+++ b/addons/common/functions/fnc_initSliderEdit.sqf
@@ -3,6 +3,15 @@
  * Author: mharis001
  * Initializes a slider with an edit box showing its value.
  *
+ * Formatting can be specified as:
+ *   - NUMBER of displayed decimal places.
+ *   - CODE which is passed the value (_this) and must return a STRING.
+ *
+ * Is Percentage will make the slider and edit controls properly handle the value as a percentage.
+ * The displayed value will be multiplied by 100 and formatted with a percent sign.
+ * The returned value will still be within the min and max values (ideally 0 to 1).
+ * This allows the user to input a percent from 0 to 100 instead of 0 to 1.
+ *
  * Arguments:
  * 0: Slider <CONTROL>
  * 1: Edit <CONTROL>
@@ -10,38 +19,46 @@
  * 3: Max <NUMBER>
  * 4: Value <NUMBER>
  * 5: Speed <NUMBER>
- * 6: Decimals <NUMBER> (default: 0)
- * 7: Formatting <STRING> (default: "%1")
+ * 6: Formatting <NUMBER|CODE> (default: 0)
+ * 7: Is Percentage <BOOL> (default: false)
  *
  * Return Value:
  * None
  *
  * Example:
- * [CONTROL, CONTROL, 0.5, 0, 1, 0.05, 2] call zen_common_fnc_initSliderEdit
+ * [CONTROL, CONTROL, 0, 1, 0.5, 0.05, 0] call zen_common_fnc_initSliderEdit
  *
  * Public: No
  */
 
-params ["_ctrlSlider", "_ctrlEdit", "_min", "_max", "_value", "_speed", ["_decimals", 0, [0]], ["_formatting", "%1", [""]]];
+params ["_ctrlSlider", "_ctrlEdit", "_min", "_max", "_value", "_speed", ["_formatting", 0, [0, {}]], ["_isPercentage", false, [false]]];
+
+private _fnc_getFormattedValue = {
+    if (_isPercentage) then {
+        format [localize "STR_3DEN_percentageUnit", round (_value * 100), "%"];
+    } else {
+        if (_formatting isEqualType 0) then {
+            [_value, 1, _formatting] call CBA_fnc_formatNumber;
+        } else {
+            _value call _formatting;
+        };
+    };
+};
 
 _ctrlSlider sliderSetRange [_min, _max];
 _ctrlSlider sliderSetSpeed [_speed, _speed];
 _ctrlSlider sliderSetPosition _value;
-
-_ctrlSlider setVariable [QGVAR(params), [_ctrlEdit, _decimals, _formatting]];
+_ctrlSlider setVariable [QGVAR(params), [_ctrlEdit, _formatting, _isPercentage, _fnc_getFormattedValue]];
 
 _ctrlSlider ctrlAddEventHandler ["SliderPosChanged", {
     params ["_ctrlSlider", "_value"];
-    (_ctrlSlider getVariable QGVAR(params)) params ["_ctrlEdit", "_decimals", "_formatting"];
+    (_ctrlSlider getVariable QGVAR(params)) params ["_ctrlEdit", "_formatting", "_isPercentage", "_fnc_getFormattedValue"];
 
-    private _formattedValue = format [_formatting, [_value, 1, _decimals] call CBA_fnc_formatNumber];
-    _ctrlEdit ctrlSetText _formattedValue;
+    _ctrlEdit ctrlSetText call _fnc_getFormattedValue;
 }];
 
-private _formattedValue = format [_formatting, [_value, 1, _decimals] call CBA_fnc_formatNumber];
-_ctrlEdit ctrlSetText _formattedValue;
-
-_ctrlEdit setVariable [QGVAR(params), [_ctrlSlider, _decimals, _formatting]];
+_ctrlEdit ctrlSetText call _fnc_getFormattedValue;
+_ctrlEdit setVariable [QGVAR(params), [_ctrlSlider, _formatting, _isPercentage, _fnc_getFormattedValue]];
 
 _ctrlEdit ctrlAddEventHandler ["KeyUp", {
     params ["_ctrlEdit"];
@@ -53,9 +70,8 @@ _ctrlEdit ctrlAddEventHandler ["KeyUp", {
 
 _ctrlEdit ctrlAddEventHandler ["KillFocus", {
     params ["_ctrlEdit"];
-    (_ctrlEdit getVariable QGVAR(params)) params ["_ctrlSlider", "_decimals", "_formatting"];
+    (_ctrlEdit getVariable QGVAR(params)) params ["_ctrlSlider", "_formatting", "_isPercentage", "_fnc_getFormattedValue"];
 
     private _value = sliderPosition _ctrlSlider;
-    private _formattedValue = format [_formatting, [_value, 1, _decimals] call CBA_fnc_formatNumber];
-    _ctrlEdit ctrlSetText _formattedValue;
+    _ctrlEdit ctrlSetText call _fnc_getFormattedValue;
 }];

--- a/addons/common/functions/fnc_initSliderEdit.sqf
+++ b/addons/common/functions/fnc_initSliderEdit.sqf
@@ -65,6 +65,11 @@ _ctrlEdit ctrlAddEventHandler ["KeyUp", {
     (_ctrlEdit getVariable QGVAR(params)) params ["_ctrlSlider"];
 
     private _value = parseNumber ctrlText _ctrlEdit;
+
+    if (_isPercentage) then {
+        _value = _value / 100;
+    };
+
     _ctrlSlider sliderSetPosition _value;
 }];
 

--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -89,6 +89,9 @@
         _ctrl ctrlSetBackgroundColor _color; \
     )
 
+
+#define DEGREE_SYMBOL toString [176]
+
 #ifdef DISABLE_COMPILE_CACHE
     #undef PREP
     #define PREP(fncName) FUNC(fncName) = compile preprocessFileLineNumbers QPATHTOF(functions\DOUBLES(fnc,fncName).sqf)

--- a/addons/modules/script_component.hpp
+++ b/addons/modules/script_component.hpp
@@ -163,7 +163,5 @@
 
 #define CAS_WEAPON_TYPES [["machinegun"], ["missilelauncher"], ["machinegun", "missilelauncher"], ["bomblauncher"]]
 
-#define DEGREE_SYMBOL (toString [176])
-
 #define MS_TO_KMH(value) ((value) * 3.6)
 #define KMH_TO_MS(value) ((value) / 3.6)


### PR DESCRIPTION
**When merged this pull request will:**
- Add ability to create area markers with Zeus
- Can be created by either using the module or context menu on the map
- Can be moved around by clicking on the center icon and dragging
- Properties can be edited by double clicking on the center icon
- Can be deleted by hovering over the center icon and pressing delete key
- One small annoyance is pressing escape to close the configure menu also closes the map
    - No workaround, hard coded engine behaviour (ignores handled KeyDown EH)
    - Can't manually use `ctrlShow` on the map control either
- Improve `initSliderEdit` common function with support for percentage sliders and CODE as formatting parameter

<details>
<summary>Image</summary>

![area_markers](https://user-images.githubusercontent.com/34453221/62831199-5fc48700-bbe9-11e9-8b10-9749a75184ab.png)


</details>