### PR TITLE
Context menu support for dynamic children actions

### DIFF
--- a/addons/context_menu/XEH_PREP.hpp
+++ b/addons/context_menu/XEH_PREP.hpp
@@ -1,7 +1,9 @@
 PREP(addAction);
 PREP(closeMenu);
 PREP(compileActions);
+PREP(createAction);
 PREP(createContextGroup);
+PREP(getActiveActions);
 PREP(getContextPos);
 PREP(initDisplayCurator);
 PREP(openMenu);

--- a/addons/context_menu/functions/fnc_addAction.sqf
+++ b/addons/context_menu/functions/fnc_addAction.sqf
@@ -1,22 +1,18 @@
 #include "script_component.hpp"
 /*
  * Author: mharis001
- * Adds an action to the Zeus context menu.
+ * Adds the given action to the ZEN context menu.
  *
  * Arguments:
- * 0: Parent Path <ARRAY>
- * 1: Action Name <STRING>
- * 2: Display Name <STRING>
- * 3: Icon and Icon Color <STRING|ARRAY>
- * 4: Statement <CODE>
- * 5: Condition <CODE> (default: {true})
- * 6: Priority <NUMBER> (default: 0)
+ * 0: Action <ARRAY>
+ * 1: Parent Path <ARRAY> (default: [])
+ * 2: Priority <NUMBER> (default: 0)
  *
  * Return Value:
  * Full Action Path <ARRAY>
  *
  * Example:
- * [[], "HintTime", "Hint Time", "", {hint ([daytime] call BIS_fnc_timeToString)}] call zen_context_menu_fnc_addAction
+ * [_action, [], 0] call zen_context_menu_fnc_addAction
  *
  * Public: Yes
  */
@@ -29,20 +25,7 @@ if (!hasInterface) exitWith {
     []
 };
 
-params [
-    ["_parentPath", [], []],
-    ["_actionName", "", [""]],
-    ["_displayName", "", [""]],
-    ["_iconArg", "", ["", []]],
-    ["_statement", {}, [{}]],
-    ["_condition", {true}, [{}]],
-    ["_priority", 0, [0]]
-];
-
-_iconArg params [
-    ["_iconFile", "", [""]],
-    ["_iconColor", [1, 1, 1, 1], [[]], 4]
-];
+params [["_action", [], [[]], 9], ["_parentPath", [], []], ["_priority", 0, [0]]];
 
 scopeName "Main";
 
@@ -53,14 +36,14 @@ private _parentNode = if (_parentPath isEqualTo []) then {
         params ["_actions", "_level"];
 
         private _index = _actions findIf {
-            (_x select 0) isEqualTo (_parentPath select _level);
+            (_x select 0 select 0) isEqualTo (_parentPath select _level);
         };
 
         if (_index == -1) then {
-            ERROR_2("Failed to add action (%1) to parent path %2",_actionName,_parentPath);
+            ERROR_2("Failed to add action (%1) to parent path %2",_action select 0,_parentPath);
             [] breakOut "Main";
         } else {
-            private _children = _actions select _index select 7;
+            private _children = _actions select _index select 1;
 
             if (count _parentPath == _level + 1) then {
                 _children
@@ -73,7 +56,7 @@ private _parentNode = if (_parentPath isEqualTo []) then {
     [GVAR(actions), 0] call _fnc_findNode;
 };
 
-_parentNode pushBack [_actionName, _displayName, _iconFile, _iconColor, _statement, _condition, _priority, []];
-[_parentNode, 6, false] call CBA_fnc_sortNestedArray;
+_parentNode pushBack [_action, [], _priority];
+[_parentNode, 2, false] call CBA_fnc_sortNestedArray;
 
-_parentPath + [_actionName]
+_parentPath + [_action select 0]

--- a/addons/context_menu/functions/fnc_addAction.sqf
+++ b/addons/context_menu/functions/fnc_addAction.sqf
@@ -25,7 +25,13 @@ if (!hasInterface) exitWith {
     []
 };
 
-params [["_action", [], [[]], 9], ["_parentPath", [], []], ["_priority", 0, [0]]];
+params [
+    ["_action", [], [[]], 9],
+    ["_parentPath", [], []],
+    ["_priority", 0, [0]]
+];
+
+_action params ["_actionName"];
 
 scopeName "Main";
 
@@ -40,7 +46,7 @@ private _parentNode = if (_parentPath isEqualTo []) then {
         };
 
         if (_index == -1) then {
-            ERROR_2("Failed to add action (%1) to parent path %2",_action select 0,_parentPath);
+            ERROR_2("Failed to add action (%1) to parent path %2.",_actionName,_parentPath);
             [] breakOut "Main";
         } else {
             private _children = _actions select _index select 1;
@@ -59,4 +65,4 @@ private _parentNode = if (_parentPath isEqualTo []) then {
 _parentNode pushBack [_action, [], _priority];
 [_parentNode, 2, false] call CBA_fnc_sortNestedArray;
 
-_parentPath + [_action select 0]
+_parentPath + [_actionName]

--- a/addons/context_menu/functions/fnc_compileActions.sqf
+++ b/addons/context_menu/functions/fnc_compileActions.sqf
@@ -104,7 +104,7 @@ missionNamespace setVariable [QGVAR(actions), _contextActions];
             _iconColor,
             _statement,
             _condition,
-            _arguments,
+            _args,
             _insertChildren,
             _modifierFunction
         ],

--- a/addons/context_menu/functions/fnc_compileActions.sqf
+++ b/addons/context_menu/functions/fnc_compileActions.sqf
@@ -34,20 +34,28 @@ private _fnc_getActionData = {
         private _condition = compile getText (_entryConfig >> "condition");
         if (_condition isEqualTo {}) then {_condition = {true}};
 
-        private _priority = getNumber (_entryConfig >> "priority");
+        private _insertChildren = compile getText (_entryConfig >> "insertChildren");
+        private _modifierFunction = compile getText (_entryConfig >> "modifierFunction");
 
         private _children = [_entryConfig] call _fnc_getActionData;
-        [_children, 6, false] call CBA_fnc_sortNestedArray;
+        [_children, 2, false] call CBA_fnc_sortNestedArray;
+
+        private _priority = getNumber (_entryConfig >> "priority");
 
         private _actionEntry = [
-            _actionName,
-            _displayName,
-            _iconFile,
-            _iconColor,
-            _statement,
-            _condition,
-            _priority,
-            _children
+            [
+                _actionName,
+                _displayName,
+                _iconFile,
+                _iconColor,
+                _statement,
+                _condition,
+                [],
+                _insertChildren,
+                _modifierFunction
+            ],
+            _children,
+            _priority
         ];
 
         _actions pushBack _actionEntry;
@@ -65,21 +73,22 @@ private _fnc_addMissionActions = {
     params ["_actionsArray", "_actionsToAdd"];
 
     {
-        _x params ["_actionName", "", "", "", "", "", "", "_actionChildren"];
+        _x params ["_action", "_actionChildren"];
+        _action params ["_actionName"];
 
         private _index = _actionsArray findIf {
-            (_x select 0) isEqualTo _actionName;
+            (_x select 0 select 0) isEqualTo _actionName;
         };
 
         if (_index == -1) then {
             _actionsArray pushBack _x;
         } else {
-            private _children = _actionsArray select _index select 7;
+            private _children = _actionsArray select _index select 1;
             [_children, _actionChildren] call _fnc_addMissionActions;
         };
     } forEach _actionsToAdd;
 
-    [_actionsArray, 6, false] call CBA_fnc_sortNestedArray;
+    [_actionsArray, 2, false] call CBA_fnc_sortNestedArray;
 };
 
 [_contextActions, _missionActions] call _fnc_addMissionActions;
@@ -88,14 +97,19 @@ missionNamespace setVariable [QGVAR(actions), _contextActions];
 /*
 [
     [
-        _actionName,
-        _displayName,
-        _iconFile,
-        _iconColor,
-        _statement,
-        _condition,
-        _priority,
-        [childrenActions]
+        [
+            _actionName,
+            _displayName,
+            _iconFile,
+            _iconColor,
+            _statement,
+            _condition,
+            _arguments,
+            _insertChildren,
+            _modifierFunction
+        ],
+        [childrenActions],
+        _priority
     ]
 ]
 */

--- a/addons/context_menu/functions/fnc_createAction.sqf
+++ b/addons/context_menu/functions/fnc_createAction.sqf
@@ -1,0 +1,52 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Creates an isolated context menu action.
+ * Used to ensure that the action array is in the correct format.
+ *
+ * Arguments:
+ * 0: Action Name <STRING>
+ * 1: Display Name <STRING>
+ * 2: Icon and Icon Color <STRING|ARRAY>
+ * 3: Statement <CODE>
+ * 4: Condition <CODE> (default: {true})
+ * 5: Arguments <ANY> (default: [])
+ * 6: Dynamic Children <CODE> (default: {})
+ * 7: Modifier Function <CODE> (default: {})
+ *
+ * Return Value:
+ * Action <ARRAY>
+ *
+ * Example:
+ * ["HintTime", "Hint Time", "", {hint ([daytime] call BIS_fnc_timeToString)}] call zen_context_menu_fnc_createAction
+ *
+ * Public: Yes
+ */
+
+params [
+    ["_actionName", "", [""]],
+    ["_displayName", "", [""]],
+    ["_iconArg", "", ["", []]],
+    ["_statement", {}, [{}]],
+    ["_condition", {true}, [{}]],
+    ["_arguments", []],
+    ["_insertChildren", {}, [{}]],
+    ["_modifierFunction", {}, [{}]]
+];
+
+_iconArg params [
+    ["_iconFile", "", [""]],
+    ["_iconColor", [1, 1, 1, 1], [[]], 4]
+];
+
+[
+    _actionName,
+    _displayName,
+    _iconFile,
+    _iconColor,
+    _statement,
+    _condition,
+    _arguments,
+    _insertChildren,
+    _modifierFunction
+]

--- a/addons/context_menu/functions/fnc_createAction.sqf
+++ b/addons/context_menu/functions/fnc_createAction.sqf
@@ -29,7 +29,7 @@ params [
     ["_iconArg", "", ["", []]],
     ["_statement", {}, [{}]],
     ["_condition", {true}, [{}]],
-    ["_arguments", []],
+    ["_args", []],
     ["_insertChildren", {}, [{}]],
     ["_modifierFunction", {}, [{}]]
 ];
@@ -46,7 +46,7 @@ _iconArg params [
     _iconColor,
     _statement,
     _condition,
-    _arguments,
+    _args,
     _insertChildren,
     _modifierFunction
 ]

--- a/addons/context_menu/functions/fnc_createContextGroup.sqf
+++ b/addons/context_menu/functions/fnc_createContextGroup.sqf
@@ -35,7 +35,7 @@ private _numberOfRows = 0;
 
 {
     _x params ["_action", "_children"];
-    _action params ["", "_displayName", "_icon", "_iconColor", "_statement", "_condition", "_arguments"];
+    _action params ["", "_displayName", "_icon", "_iconColor", "_statement", "_condition", "_args"];
 
     // Create context row control
     private _ctrlContextRow = _display ctrlCreate [QGVAR(row), IDC_CONTEXT_ROW, _ctrlContextGroup];
@@ -92,10 +92,7 @@ private _numberOfRows = 0;
 
         if (_button isEqualTo 0) then {
             private _ctrlContextRow = ctrlParentControlsGroup _ctrlMouse;
-
-            private _condition = _ctrlContextRow getVariable QGVAR(condition);
-            private _statement = _ctrlContextRow getVariable QGVAR(statement);
-            private _arguments = _ctrlContextRow getVariable QGVAR(arguments);
+            (_ctrlContextRow getVariable QGVAR(params)) params ["_condition", "_statement", "_args"];
 
             // Exit on empty statement, the menu should not close when the action does nothing
             if (_statement isEqualTo {}) exitWith {};
@@ -109,9 +106,7 @@ private _numberOfRows = 0;
         };
     }];
 
-    _ctrlContextRow setVariable [QGVAR(condition), _condition];
-    _ctrlContextRow setVariable [QGVAR(statement), _statement];
-    _ctrlContextRow setVariable [QGVAR(arguments), _arguments];
+    _ctrlContextRow setVariable [QGVAR(params), [_condition, _statement, _args]];
     _ctrlContextRow setVariable [QGVAR(children), _children];
 
     // Update row position in group

--- a/addons/context_menu/functions/fnc_createContextGroup.sqf
+++ b/addons/context_menu/functions/fnc_createContextGroup.sqf
@@ -22,12 +22,6 @@ params [["_contextActions", []], ["_contextLevel", 0], ["_parentRow", controlNul
 // Exit if no context actions provided
 if (_contextActions isEqualTo []) exitWith {};
 
-// Check action conditions
-SETUP_ACTION_VARS;
-_contextActions = _contextActions select {
-    ACTION_PARAMS call (_x select 5);
-};
-
 // Create context group control
 private _display = findDisplay IDD_RSCDISPLAYCURATOR;
 private _ctrlContextGroup = _display ctrlCreate [QGVAR(group), IDC_CONTEXT_GROUP];
@@ -40,7 +34,8 @@ GVAR(contextGroups) set [_contextLevel, _ctrlContextGroup];
 private _numberOfRows = 0;
 
 {
-    _x params ["", "_displayName", "_icon", "_iconColor", "_statement", "_condition", "", "_children"];
+    _x params ["_action", "_children"];
+    _action params ["", "_displayName", "_icon", "_iconColor", "_statement", "_condition", "_arguments"];
 
     // Create context row control
     private _ctrlContextRow = _display ctrlCreate [QGVAR(row), IDC_CONTEXT_ROW, _ctrlContextGroup];
@@ -73,7 +68,7 @@ private _numberOfRows = 0;
 
         // Close previously opened child context groups
         private _contextLevel = _ctrlContextGroup getVariable QGVAR(level);
-        for "_i" from (_contextLevel + 1) to (count GVAR(contextGroups) -1) do {
+        for "_i" from (_contextLevel + 1) to (count GVAR(contextGroups) - 1) do {
             ctrlDelete (GVAR(contextGroups) select _i);
         };
 
@@ -100,6 +95,7 @@ private _numberOfRows = 0;
 
             private _condition = _ctrlContextRow getVariable QGVAR(condition);
             private _statement = _ctrlContextRow getVariable QGVAR(statement);
+            private _arguments = _ctrlContextRow getVariable QGVAR(arguments);
 
             // Exit on empty statement, the menu should not close when the action does nothing
             if (_statement isEqualTo {}) exitWith {};
@@ -115,6 +111,7 @@ private _numberOfRows = 0;
 
     _ctrlContextRow setVariable [QGVAR(condition), _condition];
     _ctrlContextRow setVariable [QGVAR(statement), _statement];
+    _ctrlContextRow setVariable [QGVAR(arguments), _arguments];
     _ctrlContextRow setVariable [QGVAR(children), _children];
 
     // Update row position in group

--- a/addons/context_menu/functions/fnc_getActiveActions.sqf
+++ b/addons/context_menu/functions/fnc_getActiveActions.sqf
@@ -1,0 +1,54 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Returns the currently active actions from the given actions.
+ *
+ * Arguments:
+ * 0: Actions <ARRAY>
+ *
+ * Return Value:
+ * Active Actions <ARRAY>
+ *
+ * Example:
+ * [_actions] call zen_context_menu_fnc_getActiveActions
+ *
+ * Public: No
+ */
+
+params ["_actions"];
+
+SETUP_ACTION_VARS;
+
+private _activeActions = [];
+
+{
+    _x params ["_action", "_children", "_priority"];
+    _action params ["", "", "", "", "_statement", "_condition", "_arguments", "_insertChildren", "_modifierFunction"];
+
+    // Check if the action should modified first
+    if !(_modifierFunction isEqualTo {}) then {
+        _action = +_action; // Make a copy of the action for the function to modify
+        [_action, ACTION_PARAMS] call _modifierFunction;
+    };
+
+    // Check if the action itself is active
+    if (ACTION_PARAMS call _condition) then {
+        // Get active children actions
+        private _activeChildren = [_children] call FUNC(getActiveActions);
+
+        // Check if the action has code to insert children dynamically
+        if !(_insertChildren isEqualTo {}) then {
+            private _dynamicChildren = ACTION_PARAMS call _insertChildren;
+            [_dynamicChildren, 2, false] call CBA_fnc_sortNestedArray;
+
+            _activeChildren append ([_dynamicChildren] call FUNC(getActiveActions));
+        };
+
+        // Only add the action to active actions if its statement is not empty or it has active children
+        if !(_statement isEqualTo {} && {_activeChildren isEqualTo []}) then {
+            _activeActions pushBack [_action, _activeChildren, _priority];
+        };
+    };
+} forEach _actions;
+
+_activeActions

--- a/addons/context_menu/functions/fnc_getActiveActions.sqf
+++ b/addons/context_menu/functions/fnc_getActiveActions.sqf
@@ -23,7 +23,7 @@ private _activeActions = [];
 
 {
     _x params ["_action", "_children", "_priority"];
-    _action params ["", "", "", "", "_statement", "_condition", "_arguments", "_insertChildren", "_modifierFunction"];
+    _action params ["", "", "", "", "_statement", "_condition", "_args", "_insertChildren", "_modifierFunction"];
 
     // Check if the action should modified first
     if !(_modifierFunction isEqualTo {}) then {

--- a/addons/context_menu/functions/fnc_openMenu.sqf
+++ b/addons/context_menu/functions/fnc_openMenu.sqf
@@ -47,4 +47,5 @@ if (_category != -1) then {
 };
 
 // Create base level context menu
-[GVAR(actions)] call FUNC(createContextGroup);
+private _actions = [GVAR(actions)] call FUNC(getActiveActions);
+[_actions] call FUNC(createContextGroup);

--- a/addons/context_menu/script_component.hpp
+++ b/addons/context_menu/script_component.hpp
@@ -42,4 +42,4 @@
     private _hoveredEntity = GVAR(hovered); \
     +GVAR(selected) params ["_selectedObjects", "_selectedGroups", "_selectedWaypoints", "_selectedMarkers"]
 
-#define ACTION_PARAMS [_contextPosASL, _selectedObjects, _selectedGroups, _selectedWaypoints, _selectedMarkers, _hoveredEntity, _arguments]
+#define ACTION_PARAMS [_contextPosASL, _selectedObjects, _selectedGroups, _selectedWaypoints, _selectedMarkers, _hoveredEntity, _args]

--- a/addons/context_menu/script_component.hpp
+++ b/addons/context_menu/script_component.hpp
@@ -38,8 +38,8 @@
 #define SPACING_H POS_H(0.2)
 
 #define SETUP_ACTION_VARS \
-    private _contextPosASL = call FUNC(getContextPos);\
-    private _hoveredEntity = GVAR(hovered);\
+    private _contextPosASL = call FUNC(getContextPos); \
+    private _hoveredEntity = GVAR(hovered); \
     +GVAR(selected) params ["_selectedObjects", "_selectedGroups", "_selectedWaypoints", "_selectedMarkers"]
 
-#define ACTION_PARAMS [_contextPosASL, _selectedObjects, _selectedGroups, _selectedWaypoints, _selectedMarkers, _hoveredEntity]
+#define ACTION_PARAMS [_contextPosASL, _selectedObjects, _selectedGroups, _selectedWaypoints, _selectedMarkers, _hoveredEntity, _arguments]

--- a/docs/context_menu.md
+++ b/docs/context_menu.md
@@ -7,6 +7,9 @@ The ZEN context menu framework provides convenient, intuitive access to common Z
 Context menu actions are added as subclasses to the `zen_context_menu_actions` root config class.
 Children actions are also added as subclasses.
 
+Actions can be added to both the global config `configFile` and the mission config `missionConfigFile`.
+Mission config actions can add to action paths that exist from the global config.
+
 **Config Entries:**
 
 Name | Type | Description
@@ -17,6 +20,8 @@ Name | Type | Description
 `statement` | STRING | Code called when action is clicked
 `condition` | STRING | Condition code required to show action
 `priority` | NUMBER | Action sorting priority
+`insertChildren` | STRING | Code to dynamically add children actions
+`modifierFunction` | STRING | Code to modify the action before condition checking
 
 **Example:**
 
@@ -33,20 +38,47 @@ class zen_context_menu_actions {
 
 ## Adding Actions Through Script
 
-Context menu actions can be added by calling the `zen_context_menu_fnc_addAction` function.
+#### Creating an Action
+
+Context menu actions can be added by first creating an action with the `zen_context_menu_fnc_createAction` function.
+This function is used to ensure that the created action array is in the correct format.
+
+**Arguments:**
+
+ \#   | Description | Type | Default Value (if optional)
+:---: | ----------- | ---- | ---------------------------
+0 | Action Name | STRING |
+1 | Display Name | STRING |
+2 | Icon and Icon Color | STRING or ARRAY | ["", [1, 1, 1, 1]]
+3 | Statement | CODE |
+4 | Condition | CODE | {true}
+5 | Arguments | ANY | []
+6 | Dynamic Children | CODE | {}
+7 | Modifier Function | CODE | {}
+
+**Return Value:**
+
+&nbsp;&nbsp;&nbsp;&nbsp;Action &lt;ARRAY&gt;
+
+**Example:**
+
+```clike
+["HintTime", "Hint Time", "", {hint ([daytime] call BIS_fnc_timeToString)}] call zen_context_menu_fnc_createAction
+```
+
+#### Adding the Created Action
+
+The created action can be added using the `zen_context_menu_fnc_addAction` function.
+Using the an empty parent path adds the action to the root level.
 Actions are added locally and as a result the function must be executed on each client in order to have global effects.
 
 **Arguments:**
 
  \#   | Description | Type | Default Value (if optional)
 :---: | ----------- | ---- | ---------------------------
-0 | Parent Path | ARRAY |
-1 | Action Name | STRING |
-2 | Display Name | STRING |
-3 | Icon and Icon Color | STRING or ARRAY | ["", [1, 1, 1, 1]]
-4 | Statement | CODE |
-5 | Condition | CODE | {true}
-6 | Priority | NUMBER | 0
+0 | Action | ARRAY
+1 | Parent Path | ARRAY | []
+2 | Priority | NUMBER | 0
 
 **Return Value:**
 
@@ -55,19 +87,25 @@ Actions are added locally and as a result the function must be executed on each 
 **Example:**
 
 ```clike
-[[], "HintTime", "Hint Time", "", {hint ([daytime] call BIS_fnc_timeToString)}] call zen_context_menu_fnc_addAction
+[_action, [], 0] call zen_context_menu_fnc_addAction
 ```
+
+Once the action is c
 
 ## Statement and Condition
 
 The `statement` and `condition` code blocks are both executed in the **unscheduled** environment.
 The `condition` code **must** return a BOOL indicating whether the action should be shown.
 
+Actions that have an empty statement and no active children are not shown.
+This removes the need to duplicate condition checks for actions that are only there to categorize others.
+
 **Passed Parameters:**
 
 - The variable column references the name of local scope variable corresponding to the given parameter (for easy access, especially in configs).
 - Context position is taken from the top-left corner of the menu, in format ASL.
 - Hovered entity is the Zeus entity being hovered when the menu was opened. It is also included in its corresponding selected array. `objNull` if nothing was hovered.
+- Arguments is the custom argument(s) given to the action when it was created.
 
 
  \#   | Description | Type | Variable
@@ -78,3 +116,30 @@ The `condition` code **must** return a BOOL indicating whether the action should
 3 | Selected Waypoints | ARRAY | `_selectedWaypoints`
 4 | Selected Markers | ARRAY | `_selectedMarkers`
 5 | Hovered Entity | OBJECT, GROUP,<br/>ARRAY, or STRING | `_hoveredEntity`
+6 | Arguments | ANY | `_args`
+
+## Dynamic Children Actions
+
+Dynamic children actions can be added to an action by returning an array of actions from the insert children code.
+The same parameters that are available to the statement and condition are also available here.
+
+Each action in the array must be in the following format:
+
+- 0: Action (created using `zen_context_menu_fnc_createAction`) &lt;ARRAY&gt;
+- 1: Array of Children Actions &lt;ARRAY&gt;
+- 2: Priority &lt;NUMBER&gt;
+
+These actions are sorted based on priority with all of the children of the action and undergo the same condition checking to be shown.
+
+## Modifier Function
+
+The modifier function can be used to dynamically modify the properties of action, such as its name based on the hovered entity.
+This is called before any other handling involving the action (condition checking, dynamic children creation) occurs.
+
+**Passed Parameters:**
+
+- 0: Action (to modify by reference) &lt;ARRAY&gt;
+- 1: Parameters (same as statement and condition) &lt;ARRAY&gt;
+
+The action is modified by changing the action array by reference.
+Each time the modifier function is called, it receives a new copy of the original action (without any previous modifications).

--- a/docs/context_menu.md
+++ b/docs/context_menu.md
@@ -38,7 +38,7 @@ class zen_context_menu_actions {
 
 ## Adding Actions Through Script
 
-_Requires Zeus Enhanced v1.4.0_
+_Requires Zeus Enhanced v1.4.0 or later._
 
 #### Creating an Action
 

--- a/docs/context_menu.md
+++ b/docs/context_menu.md
@@ -58,7 +58,7 @@ This function is used to ensure that the created action array is in the correct 
 
 **Return Value:**
 
-&nbsp;&nbsp;&nbsp;&nbsp;Action &lt;ARRAY&gt;
+- Action &lt;ARRAY&gt;
 
 **Example:**
 
@@ -82,15 +82,13 @@ Actions are added locally and as a result the function must be executed on each 
 
 **Return Value:**
 
-&nbsp;&nbsp;&nbsp;&nbsp;Full Action Path &lt;ARRAY&gt;
+- Full Action Path &lt;ARRAY&gt;
 
 **Example:**
 
 ```clike
 [_action, [], 0] call zen_context_menu_fnc_addAction
 ```
-
-Once the action is c
 
 ## Statement and Condition
 

--- a/docs/context_menu.md
+++ b/docs/context_menu.md
@@ -38,6 +38,8 @@ class zen_context_menu_actions {
 
 ## Adding Actions Through Script
 
+_Requires Zeus Enhanced v1.4.0_
+
 #### Creating an Action
 
 Context menu actions can be added by first creating an action with the `zen_context_menu_fnc_createAction` function.
@@ -100,7 +102,7 @@ This removes the need to duplicate condition checks for actions that are only th
 
 **Passed Parameters:**
 
-- The variable column references the name of local scope variable corresponding to the given parameter (for easy access, especially in configs).
+- The variable column references the name of the local scope variable corresponding to the given parameter (for easy access, especially in configs).
 - Context position is taken from the top-left corner of the menu, in format ASL.
 - Hovered entity is the Zeus entity being hovered when the menu was opened. It is also included in its corresponding selected array. `objNull` if nothing was hovered.
 - Arguments is the custom argument(s) given to the action when it was created.
@@ -121,7 +123,7 @@ This removes the need to duplicate condition checks for actions that are only th
 Dynamic children actions can be added to an action by returning an array of actions from the insert children code.
 The same parameters that are available to the statement and condition are also available here.
 
-Each action in the array must be in the following format:
+Each action in the returned actions must be an array with the following format:
 
 - 0: Action (created using `zen_context_menu_fnc_createAction`) &lt;ARRAY&gt;
 - 1: Array of Children Actions &lt;ARRAY&gt;

--- a/docs/custom_modules.md
+++ b/docs/custom_modules.md
@@ -20,7 +20,7 @@ Modules are added locally and as a result the function must be executed on each 
 
 **Return Value:**
 
-&nbsp;&nbsp;&nbsp;&nbsp;Successfully Registered &lt;BOOL&gt;
+- Successfully Registered &lt;BOOL&gt;
 
 **Example:**
 

--- a/docs/public_events.md
+++ b/docs/public_events.md
@@ -10,7 +10,7 @@ Executed **locally** when the Zeus display is loaded.
 
 **Parameters:**
 
-&nbsp;&nbsp;&nbsp;&nbsp;0: Zeus Display &lt;DISPLAY&gt;
+- 0: Zeus Display &lt;DISPLAY&gt;
 
 ---
 
@@ -20,7 +20,7 @@ Executed **locally** when the Zeus display is unloaded.
 
 **Parameters:**
 
-&nbsp;&nbsp;&nbsp;&nbsp;0: Zeus Display &lt;DISPLAY&gt;
+- 0: Zeus Display &lt;DISPLAY&gt;
 
 ---
 
@@ -30,4 +30,4 @@ Executed **locally** when Zeus starts remote controlling a unit.
 
 **Parameters:**
 
-&nbsp;&nbsp;&nbsp;&nbsp;0: Unit &lt;OBJECT&gt;
+- 0: Unit &lt;OBJECT&gt;


### PR DESCRIPTION
**When merged this pull request will:**
- Add dynamic children actions support for the context menu
- Add support for custom action arguments which are available in the action's code blocks
- Add modifier function that allows for dynamically modifying an action when the menu is opened
- Only actions that don't have an empty statement or have active children will be shown now
    - Removes need to duplicate checks inside of children actions into the parent action to hide it if children are inactive
- Move active actions checking outside of `createContextGroup`
    - Now active actions are only collected once (when opening)
- Backwards incompatible change for adding actions through script (config will stay the same)

**Todo:**
- [x] Update docs
