### PR TITLE
Visibility indicator tweaks

### DIFF
--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -17,6 +17,7 @@ PREP(getTurretMagazines);
 PREP(getVehicleAmmo);
 PREP(healUnit);
 PREP(initSliderEdit);
+PREP(isInScreenshotMode);
 PREP(isPlacementActive);
 PREP(openArsenal);
 PREP(setInventory);

--- a/addons/common/functions/fnc_isInScreenshotMode.sqf
+++ b/addons/common/functions/fnc_isInScreenshotMode.sqf
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Checks if the Zeus display is in screenshot mode.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * In Screenshot Mode <BOOL>
+ *
+ * Example:
+ * [] call zen_common_fnc_isInScreenshotMode
+ *
+ * Public: No
+ */
+
+uiNamespace getVariable ["RscDisplayCurator_screenshotMode", false]

--- a/addons/visibility/functions/fnc_draw.sqf
+++ b/addons/visibility/functions/fnc_draw.sqf
@@ -19,10 +19,10 @@
 private _pos = AGLtoASL screenToWorld getMousePosition;
 private _intersections = lineIntersectsSurfaces [getPosASL curatorCamera, _pos];
 if !(_intersections isEqualTo []) then {
-    _pos = ((_intersections select 0) select 0);
+    _pos = _intersections select 0 select 0;
 };
 
-// check 1.5 above the cursor to prevent a small object on the terrain blocking the view
+// Check 1.5 above the cursor to prevent a small object on the terrain blocking the view
 private _posHigh = _pos vectorAdd [0, 0, 1.5];
 private _draw = false;
 {
@@ -31,8 +31,10 @@ private _draw = false;
         if (lineIntersectsSurfaces [_eyePos, _pos, _x, objNull] isEqualTo [] || {lineIntersectsSurfaces [_eyePos, _posHigh, _x, objNull] isEqualTo []}) then {
             // Check visibility through smoke
             private _visibility = [objNull, "VIEW"] checkVisibility [_eyePos, _posHigh];
+
             // Draw a line from each player that can see the cursor
             drawLine3D [ASLToAGL _eyePos, ASLToAGL _pos, [1, 0, 0, _visibility]];
+
             _draw = true;
         };
     };

--- a/addons/visibility/functions/fnc_draw.sqf
+++ b/addons/visibility/functions/fnc_draw.sqf
@@ -15,6 +15,8 @@
  * Public: No
  */
 
+if (call EFUNC(common,isInScreenshotMode)) exitWith {};
+
 // The cursor position in the world
 private _pos = AGLtoASL screenToWorld getMousePosition;
 private _intersections = lineIntersectsSurfaces [getPosASL curatorCamera, _pos];
@@ -26,7 +28,7 @@ if !(_intersections isEqualTo []) then {
 private _posHigh = _pos vectorAdd [0, 0, 1.5];
 private _draw = false;
 {
-    if (side _x != sideLogic && {(((_x getRelDir _posHigh) + 90) mod 360) < 180}) then {
+    if (_x != player && {side _x != sideLogic} && {((_x getRelDir _posHigh) + 90) mod 360 < 180}) then {
         private _eyePos = eyePos _x;
         if (lineIntersectsSurfaces [_eyePos, _pos, _x, objNull] isEqualTo [] || {lineIntersectsSurfaces [_eyePos, _posHigh, _x, objNull] isEqualTo []}) then {
             // Check visibility through smoke

--- a/addons/visibility/functions/fnc_draw.sqf
+++ b/addons/visibility/functions/fnc_draw.sqf
@@ -27,7 +27,9 @@ if !(_intersections isEqualTo []) then {
 // Check 1.5 above the cursor to prevent a small object on the terrain blocking the view
 private _posHigh = _pos vectorAdd [0, 0, 1.5];
 private _draw = false;
+
 {
+    // Check if the cursor's position is in the player's view (filter the local player and virtual units)
     if (_x != player && {side _x != sideLogic} && {((_x getRelDir _posHigh) + 90) mod 360 < 180}) then {
         private _eyePos = eyePos _x;
         if (lineIntersectsSurfaces [_eyePos, _pos, _x, objNull] isEqualTo [] || {lineIntersectsSurfaces [_eyePos, _posHigh, _x, objNull] isEqualTo []}) then {

--- a/addons/visibility/functions/fnc_draw.sqf
+++ b/addons/visibility/functions/fnc_draw.sqf
@@ -48,7 +48,7 @@ if (_draw) then {
         "",
         [1, 0, 0, 1],
         ASLToAGL _pos,
-        1, 3, 0,
+        1, 1.3, 0,
         LLSTRING(Visible),
         2,
         0.04,

--- a/addons/visibility/initSettings.sqf
+++ b/addons/visibility/initSettings.sqf
@@ -1,13 +1,15 @@
 [
     QGVAR(enabled),
     "CHECKBOX",
-    ["STR_A3_OPTIONS_ENABLED", LSTRING(enabled_Description)],
-    [ELSTRING(common,Category), "str_a3_rscdisplayoptionsvideo_textvisibility"],
-    true,
+    [LSTRING(Enabled), LSTRING(Enabled_Description)],
+    ELSTRING(common,Category),
+    false,
     false,
     {
         params ["_value"];
-        if (isNull (findDisplay IDD_RSCDISPLAYCURATOR)) exitWith {};
+
+        if (isNull findDisplay IDD_RSCDISPLAYCURATOR) exitWith {};
+
         if (_value) then {
             call FUNC(start);
         } else {

--- a/addons/visibility/stringtable.xml
+++ b/addons/visibility/stringtable.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="ZEN">
     <Package name="Visibility">
+        <Key ID="STR_ZEN_Visibility_Enabled">
+            <English>Visibility Indicator</English>
+        </Key>
         <Key ID="STR_ZEN_Visibility_Enabled_Description">
             <English>Indicates when a player can see the Zeus' cursor.</English>
         </Key>


### PR DESCRIPTION
**When merged this pull request will:**
- Move setting out of subcategory and change default to false
    - Was the only setting in the subcategory
    - Seems more users will have it turned off
- Disable drawing while the interface is in screenshot mode
    - Add `isInScreenshotMode` common function
- Move the "VISIBLE" text closer to the cursor (less vertical space)
- Don't draw an indicator for the local player (thoughts?)
