### PR TITLE
Add max distance to remote control camera exit position

### DIFF
--- a/addons/remote_control/functions/fnc_start.sqf
+++ b/addons/remote_control/functions/fnc_start.sqf
@@ -22,7 +22,9 @@ _unit = effectiveCommander _unit;
 _unit setVariable [VAR_OWNER, player, true];
 missionNamespace setVariable [VAR_UNIT, _unit];
 
-private _cameraPos = _unit worldToModel ASLtoAGL getPosASL curatorCamera;
+private _cameraDir = vectorNormalized (_unit worldToModel ASLtoAGL getPosASL curatorCamera);
+private _cameraPos = _cameraDir vectorMultiply ((_unit distance curatorCamera) min MAX_CAMERA_DISTANCE);
+
 (findDisplay IDD_RSCDISPLAYCURATOR) closeDisplay 2;
 
 [{

--- a/addons/remote_control/script_component.hpp
+++ b/addons/remote_control/script_component.hpp
@@ -20,3 +20,5 @@
 
 #define VAR_UNIT  "bis_fnc_moduleRemoteControl_unit"
 #define VAR_OWNER "bis_fnc_moduleRemoteControl_owner"
+
+#define MAX_CAMERA_DISTANCE 50


### PR DESCRIPTION
**When merged this pull request will:**
- Add max distance of 50 m from the unit for the remote control camera exit position
- If starting remote control from far away, camera is moved to the unit on exit but remains in the same direction