### PR TITLE
Add portrait entry for Smoke Pillar module

### DIFF
--- a/addons/modules/CfgVehicles.hpp
+++ b/addons/modules/CfgVehicles.hpp
@@ -299,6 +299,7 @@ class CfgVehicles {
         displayName = CSTRING(ModuleSmokePillar);
         function = QFUNC(moduleSmokePillar);
         icon = QPATHTOF(ui\smoke_pillar_ca.paa);
+        portrait = QPATHTOF(ui\smoke_pillar_ca.paa);
     };
     class GVAR(moduleSpawnCarrier): GVAR(moduleBase) {
         category = QGVAR(Spawn);


### PR DESCRIPTION
**When merged this pull request will:**
- title, module will have the smoke pillar icon when placed in the world instead of being empty