### PR TITLE
Keep factions visible when clicking the collapse all button

### DIFF
--- a/addons/editor/functions/fnc_handleTreeButtons.sqf
+++ b/addons/editor/functions/fnc_handleTreeButtons.sqf
@@ -17,8 +17,10 @@
 
 params ["_expand"];
 
+RscDisplayCurator_sections params ["_mode"];
+
 // Can't collapse or expand marker or recent trees
-if (RscDisplayCurator_sections select 0 > 2) exitWith {};
+if (_mode > 2) exitWith {};
 
 // Collapse or expand current tree
 private _ctrlTree = call EFUNC(common,getActiveTree);
@@ -27,4 +29,9 @@ if (_expand) then {
     tvExpandAll _ctrlTree;
 } else {
     _ctrlTree call EFUNC(common,collapseTree);
+
+    // For QOL, keep factions of group trees visible
+    if (_mode == 1) then {
+        _ctrlTree tvExpand [0];
+    };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- title, fix annoying behaviour resulting from having to expand the useless "side" node of group trees to view available factions
- technically, the group trees are not fully collapsed after this change but I think most users will prefer this behaviour