### PR TITLE
Improve ambient animation handling of dead units

### DIFF
--- a/addons/modules/functions/fnc_moduleAmbientAnimEnd.sqf
+++ b/addons/modules/functions/fnc_moduleAmbientAnimEnd.sqf
@@ -28,7 +28,7 @@ private _firedNearEH = _unit getVariable [QGVAR(ambientAnimFiredNearEH), -1];
 _unit removeEventHandler ["FiredNear", _firedNearEH];
 
 // If unit is alive then re-enable AI intelligence and switch to previous animation
-// If unit died, immediately reset the animation
+// If unit died, switch to the unit's death animation
 if (alive _unit) then {
     {
         [QEGVAR(common,enableAI), [_unit, _x], _unit] call CBA_fnc_targetEvent;
@@ -42,7 +42,7 @@ if (alive _unit) then {
         [QEGVAR(common,switchMove), [_unit, _previousAnim]] call CBA_fnc_globalEvent;
     };
 } else {
-    [QEGVAR(common,switchMove), [_unit, ""]] call CBA_fnc_globalEvent;
+    [QEGVAR(common,playMoveNow), [_unit, _unit call CBA_fnc_getUnitDeathAnim]] call CBA_fnc_globalEvent;
 };
 
 // Remove stored animations list and previous animation


### PR DESCRIPTION
**When merged this pull request will:**
- title, switch unit to death animation instead of animation reset