### PR TITLE
Add Toggle Editable Icons keybind

### DIFF
--- a/addons/editor/functions/fnc_handleObjectPlaced.sqf
+++ b/addons/editor/functions/fnc_handleObjectPlaced.sqf
@@ -18,6 +18,13 @@
 
 params ["", "_object"];
 
+// Re-collapse the entities tree if editable icons are hidden
+// Placing an object expands a portion of the tree
+if (!GVAR(iconsVisible)) then {
+    private _ctrlEntites = findDisplay IDD_RSCDISPLAYCURATOR displayCtrl IDC_RSCDISPLAYCURATOR_ENTITIES;
+    _ctrlEntites call EFUNC(common,collapseTree);
+};
+
 RscDisplayCurator_sections params ["_mode"];
 
 if (!GVAR(includeCrew) && {_mode == 0 || {_mode == 4 && {isClass (configFile >> "CfgVehicles" >> GVAR(recentTreeData))}}}) then {

--- a/addons/editor/functions/fnc_initDisplayCurator.sqf
+++ b/addons/editor/functions/fnc_initDisplayCurator.sqf
@@ -18,6 +18,10 @@
 
 params ["_display"];
 
+// Reset editable icons visibility tracking variable
+// Prevents unwanted behaviour if display is closed when icons are hidden
+GVAR(iconsVisible) = true;
+
 if (GVAR(removeWatermark)) then {
     private _ctrlWatermark = _display displayCtrl IDC_RSCDISPLAYCURATOR_WATERMARK;
     _ctrlWatermark ctrlSetText "";

--- a/addons/editor/functions/fnc_initDisplayCurator.sqf
+++ b/addons/editor/functions/fnc_initDisplayCurator.sqf
@@ -19,7 +19,7 @@
 params ["_display"];
 
 // Reset editable icons visibility tracking variable
-// Prevents unwanted behaviour if display is closed when icons are hidden
+// Prevents unwanted behaviour if display is closed while icons are hidden
 GVAR(iconsVisible) = true;
 
 if (GVAR(removeWatermark)) then {

--- a/addons/editor/initKeybinds.sqf
+++ b/addons/editor/initKeybinds.sqf
@@ -1,7 +1,9 @@
 [ELSTRING(common,Category), QGVAR(toggleIncludeCrew), LSTRING(ToggleIncludeCrew), {
     if (!isNull curatorCamera && {!GETMVAR(RscDisplayCurator_search,false)}) then {
         GVAR(includeCrew) = !GVAR(includeCrew);
-        (findDisplay IDD_RSCDISPLAYCURATOR displayCtrl IDC_INCLUDE_CREW) cbSetChecked GVAR(includeCrew);
+
+        private _ctrlIncludeCrew = findDisplay IDD_RSCDISPLAYCURATOR displayCtrl IDC_INCLUDE_CREW;
+        _ctrlIncludeCrew cbSetChecked GVAR(includeCrew);
     };
 }, {}, [DIK_B, [false, false, false]]] call CBA_fnc_addKeybind; // Default: B
 
@@ -24,3 +26,17 @@
         true // handled, prevents vanilla eject from activating
     };
 }, {}, [DIK_G, [false, true, false]]] call CBA_fnc_addKeybind; // Default: CTRL + G
+
+[ELSTRING(common,Category), QGVAR(toggleIcons), [LSTRING(ToggleIcons), LSTRING(ToggleIcons_Description)], {
+    if (!isNull curatorCamera && {!GETMVAR(RscDisplayCurator_search,false)}) then {
+        GVAR(iconsVisible) = !GVAR(iconsVisible);
+
+        private _ctrlEntites = findDisplay IDD_RSCDISPLAYCURATOR displayCtrl IDC_RSCDISPLAYCURATOR_ENTITIES;
+
+        if (GVAR(iconsVisible)) then {
+            tvExpandAll _ctrlEntites;
+        } else {
+            _ctrlEntites call EFUNC(common,collapseTree);
+        };
+    };
+}, {}, [0, [false, false, false]]] call CBA_fnc_addKeybind; // Default: Unbound

--- a/addons/editor/stringtable.xml
+++ b/addons/editor/stringtable.xml
@@ -87,5 +87,11 @@
             <English>Makes all selected vehicles deploy countermeasures such as smokes and flares.</English>
             <German>Alle ausgewählten Fahrzeuge setzen Gegenmaßnahmen wie Rauch und Leuchtfackeln ein.</German>
         </Key>
+        <Key ID="STR_ZEN_Editor_ToggleIcons">
+            <English>Toggle Editable Icons</English>
+        </Key>
+        <Key ID="STR_ZEN_Editor_ToggleIcons_Description">
+            <English>Toggles the visibility of all editable icons. Useful for temporarily reducing lag or onscreen clutter when there are a lot of icons.</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Add keybind to toggle visibility of editable icons
- Unlike the vanilla "Collapse / Expand Section" keybind:
    - Does not require focus to be on the entities tree
    - Hides all icons, not just a section
