### PR TITLE
Add editor preview images displaying

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Special thanks to the [ACE3 Team](http://ace3mod.com/team.html) for their open s
 - Overhauled markers tree with markers sorted into categories.
 - Ability to create and edit area markers through Zeus.
 - Rewritten, faster remote controlling of units.
-- Object editor preview images displaying in Zeus.
+- 3DEN editor object preview images in Zeus.
 - Player visibility indicator to help ensure mission adjustments are not made in view of players.
 - Vehicle customization garage made specifically for Zeus.
 - Various bug fixes and quality of life improvements to the Zeus interface.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Special thanks to the [ACE3 Team](http://ace3mod.com/team.html) for their open s
 - Overhauled markers tree with markers sorted into categories.
 - Ability to create and edit area markers through Zeus.
 - Rewritten, faster remote controlling of units.
+- Object editor preview images displaying in Zeus.
 - Player visibility indicator to help ensure mission adjustments are not made in view of players.
 - Vehicle customization garage made specifically for Zeus.
 - Various bug fixes and quality of life improvements to the Zeus interface.

--- a/addons/editor_previews/$PBOPREFIX$
+++ b/addons/editor_previews/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\zen\addons\editor_previews

--- a/addons/editor_previews/CfgEventHandlers.hpp
+++ b/addons/editor_previews/CfgEventHandlers.hpp
@@ -1,0 +1,17 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+    };
+};
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
+    };
+};

--- a/addons/editor_previews/XEH_PREP.hpp
+++ b/addons/editor_previews/XEH_PREP.hpp
@@ -1,0 +1,3 @@
+PREP(handleMouseExit);
+PREP(handleMouseUpdate);
+PREP(initDisplayCurator);

--- a/addons/editor_previews/XEH_postInit.sqf
+++ b/addons/editor_previews/XEH_postInit.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+["ZEN_displayCuratorLoad", LINKFUNC(initDisplayCurator)] call CBA_fnc_addEventHandler;

--- a/addons/editor_previews/XEH_preInit.sqf
+++ b/addons/editor_previews/XEH_preInit.sqf
@@ -1,0 +1,11 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+PREP_RECOMPILE_START;
+#include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
+
+#include "initSettings.sqf"
+
+ADDON = true;

--- a/addons/editor_previews/XEH_preStart.sqf
+++ b/addons/editor_previews/XEH_preStart.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+#include "XEH_PREP.hpp"

--- a/addons/editor_previews/config.cpp
+++ b/addons/editor_previews/config.cpp
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"zen_editor"};
+        author = ECSTRING(main,Author);
+        authors[] = {"mharis001"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgEventHandlers.hpp"
+#include "gui.hpp"

--- a/addons/editor_previews/functions/fnc_handleMouseExit.sqf
+++ b/addons/editor_previews/functions/fnc_handleMouseExit.sqf
@@ -1,0 +1,22 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles hiding the editor preview image when the mouse exits a tree.
+ *
+ * Arguments:
+ * 0: Tree <CONTROL>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [CONTROL] call zen_editor_previews_fnc_handleMouseExit
+ *
+ * Public: No
+ */
+
+params ["_ctrlTree"];
+
+private _display = ctrlParent _ctrlTree;
+private _ctrlGroup = _display displayCtrl IDC_PREVIEW_GROUP;
+_ctrlGroup ctrlShow false;

--- a/addons/editor_previews/functions/fnc_handleMouseUpdate.sqf
+++ b/addons/editor_previews/functions/fnc_handleMouseUpdate.sqf
@@ -1,0 +1,42 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles tree mouse update events by updating the editor preview image.
+ *
+ * Arguments:
+ * 0: Tree <CONTROL>
+ * 1: Path <ARRAY>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [CONTROL, []] call zen_editor_previews_fnc_handleMouseUpdate
+ *
+ * Public: No
+ */
+
+BEGIN_COUNTER(update);
+
+params ["_ctrlTree", "_path"];
+
+private _display = ctrlParent _ctrlTree;
+private _ctrlGroup = _display displayCtrl IDC_PREVIEW_GROUP;
+
+private _type = _ctrlTree tvData _path;
+
+if (_type isEqualTo "") then {
+    _ctrlGroup ctrlShow false;
+} else {
+    private _image = getText (configFile >> "CfgVehicles" >> _type >> "editorPreview");
+    if (_image isEqualTo "") exitWith {};
+
+    private _ctrlImage = _display displayCtrl IDC_PREVIEW_IMAGE;
+    _ctrlImage ctrlSetText _image;
+
+    _ctrlGroup ctrlShow true;
+    _ctrlGroup ctrlSetPositionY (getMousePosition select 1) min (safeZoneY + safeZoneH - POS_H(5.6));
+    _ctrlGroup ctrlCommit 0;
+};
+
+END_COUNTER(update);

--- a/addons/editor_previews/functions/fnc_initDisplayCurator.sqf
+++ b/addons/editor_previews/functions/fnc_initDisplayCurator.sqf
@@ -1,0 +1,36 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Initializes the Zeus display.
+ *
+ * Arguments:
+ * 0: Display <DISPLAY>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [DISPLAY] call zen_editor_previews_fnc_initDisplayCurator
+ *
+ * Public: No
+ */
+
+if (!GVAR(enabled)) exitWith {};
+
+params ["_display"];
+
+private _ctrlGroup = _display ctrlCreate [QGVAR(control), IDC_PREVIEW_GROUP];
+_ctrlGroup ctrlShow false;
+
+{
+    private _ctrlTree = _display displayCtrl _x;
+    _ctrlTree ctrlAddEventHandler ["TreeMouseMove", {call FUNC(handleMouseUpdate)}];
+    _ctrlTree ctrlAddEventHandler ["TreeMouseHold", {call FUNC(handleMouseUpdate)}];
+    _ctrlTree ctrlAddEventHandler ["TreeMouseExit", {call FUNC(handleMouseExit)}];
+} forEach [
+    IDC_RSCDISPLAYCURATOR_CREATE_UNITS_WEST,
+    IDC_RSCDISPLAYCURATOR_CREATE_UNITS_EAST,
+    IDC_RSCDISPLAYCURATOR_CREATE_UNITS_GUER,
+    IDC_RSCDISPLAYCURATOR_CREATE_UNITS_CIV,
+    IDC_RSCDISPLAYCURATOR_CREATE_UNITS_EMPTY
+];

--- a/addons/editor_previews/functions/script_component.hpp
+++ b/addons/editor_previews/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "\x\zen\addons\editor_previews\script_component.hpp"

--- a/addons/editor_previews/gui.hpp
+++ b/addons/editor_previews/gui.hpp
@@ -1,0 +1,28 @@
+class ctrlStatic;
+class ctrlStaticPictureKeepAspect;
+class ctrlControlsGroupNoScrollbars;
+
+class GVAR(control): ctrlControlsGroupNoScrollbars {
+    idc = IDC_PREVIEW_GROUP;
+    x = safeZoneX + safeZoneW - POS_EDGE(12.5,11) * GUI_GRID_W - POS_W(9.8);
+    y = 0;
+    w = POS_W(9.6);
+    h = POS_H(5.4);
+    class controls {
+        class Background: ctrlStatic {
+            idc = -1;
+            x = 0;
+            y = 0;
+            w = POS_W(9.6);
+            h = POS_H(5.4);
+            colorBackground[] = {0.1, 0.1, 0.1, 0.5};
+        };
+        class Image: ctrlStaticPictureKeepAspect {
+            idc = IDC_PREVIEW_IMAGE;
+            x = POS_W(0.1);
+            y = POS_H(0.1);
+            w = POS_W(9.4);
+            h = POS_H(5.2);
+        };
+    };
+};

--- a/addons/editor_previews/initSettings.sqf
+++ b/addons/editor_previews/initSettings.sqf
@@ -1,0 +1,8 @@
+[
+    QGVAR(enabled),
+    "CHECKBOX",
+    [LSTRING(Enabled), LSTRING(Enabled_Description)],
+    ELSTRING(common,Category),
+    true,
+    false
+] call CBA_settings_fnc_init;

--- a/addons/editor_previews/script_component.hpp
+++ b/addons/editor_previews/script_component.hpp
@@ -1,0 +1,30 @@
+#define COMPONENT editor_previews
+#define COMPONENT_BEAUTIFIED Editor Previews
+#include "\x\zen\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_EDITOR_PREVIEWS
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_EDITOR_PREVIEWS
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_EDITOR_PREVIEWS
+#endif
+
+#include "\x\zen\addons\main\script_macros.hpp"
+
+#include "\a3\ui_f\hpp\defineCommonGrids.inc"
+#include "\x\zen\addons\common\defineResinclDesign.inc"
+
+#define POS_X(N) ((N) * GUI_GRID_W + GUI_GRID_CENTER_X)
+#define POS_Y(N) ((N) * GUI_GRID_H + GUI_GRID_CENTER_Y)
+#define POS_W(N) ((N) * GUI_GRID_W)
+#define POS_H(N) ((N) * GUI_GRID_H)
+
+#define IDC_PREVIEW_GROUP 98470
+#define IDC_PREVIEW_IMAGE 98480
+
+#define POS_EDGE(DEFAULT,MOVED) ([ARR_2(DEFAULT,MOVED)] select GETMVAR(EGVAR(editor,moveDisplayToEdge),false))

--- a/addons/editor_previews/stringtable.xml
+++ b/addons/editor_previews/stringtable.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="ZEN">
+    <Package name="Editor_Previews">
+        <Key ID="STR_ZEN_Editor_Previews_Enabled">
+            <English>Editor Previews</English>
+        </Key>
+        <Key ID="STR_ZEN_Editor_Previews_Enabled_Description">
+            <English>Enables the displaying of object preview images when an item is hovered in the create trees.</English>
+        </Key>
+    </Package>
+</Project>

--- a/addons/editor_previews/stringtable.xml
+++ b/addons/editor_previews/stringtable.xml
@@ -2,10 +2,10 @@
 <Project name="ZEN">
     <Package name="Editor_Previews">
         <Key ID="STR_ZEN_Editor_Previews_Enabled">
-            <English>Editor Previews</English>
+            <English>Object Preview Images</English>
         </Key>
         <Key ID="STR_ZEN_Editor_Previews_Enabled_Description">
-            <English>Enables the displaying of object preview images when an item is hovered in the create trees.</English>
+            <English>Enables object preview images when hovering over an item in the create trees.</English>
         </Key>
     </Package>
 </Project>

--- a/docs/home.md
+++ b/docs/home.md
@@ -17,6 +17,7 @@ Special thanks to the [ACE3 Team](http://ace3mod.com/team.html) for their open s
 - Overhauled markers tree with markers sorted into categories.
 - Ability to create and edit area markers through Zeus.
 - Rewritten, faster remote controlling of units.
+- Object editor preview images displaying in Zeus.
 - Player visibility indicator to help ensure mission adjustments are not made in view of players.
 - Vehicle customization garage made specifically for Zeus.
 - Various bug fixes and quality of life improvements to the Zeus interface.

--- a/docs/home.md
+++ b/docs/home.md
@@ -17,7 +17,7 @@ Special thanks to the [ACE3 Team](http://ace3mod.com/team.html) for their open s
 - Overhauled markers tree with markers sorted into categories.
 - Ability to create and edit area markers through Zeus.
 - Rewritten, faster remote controlling of units.
-- Object editor preview images displaying in Zeus.
+- 3DEN editor object preview images in Zeus.
 - Player visibility indicator to help ensure mission adjustments are not made in view of players.
 - Vehicle customization garage made specifically for Zeus.
 - Various bug fixes and quality of life improvements to the Zeus interface.


### PR DESCRIPTION
**When merged this pull request will:**
- Add object editor preview images displaying (like 3DEN) when an item is hovered in object trees
- Can be disabled through the setting

<details>
<summary>Image</summary>

![editor_previews](https://user-images.githubusercontent.com/34453221/68460539-20044000-01d6-11ea-96da-42a0e9b2605a.png)

</details>