### PR TITLE
Fix editor preview hiding for items with no preview image

### DIFF
--- a/addons/editor_previews/functions/fnc_handleMouseUpdate.sqf
+++ b/addons/editor_previews/functions/fnc_handleMouseUpdate.sqf
@@ -29,7 +29,10 @@ if (_type isEqualTo "") then {
     _ctrlGroup ctrlShow false;
 } else {
     private _image = getText (configFile >> "CfgVehicles" >> _type >> "editorPreview");
-    if (_image isEqualTo "") exitWith {};
+
+    if (_image isEqualTo "") exitWith {
+        _ctrlGroup ctrlShow false;
+    };
 
     private _ctrlImage = _display displayCtrl IDC_PREVIEW_IMAGE;
     _ctrlImage ctrlSetText _image;


### PR DESCRIPTION
**When merged this pull request will:**
- title, hide editor preview when going from hovering an item with a preview image to one with none