### PR TITLE
Fix paradrop waypoint for Spawn Reinforcements module

### DIFF
--- a/addons/ai/functions/fnc_waypointParadrop.sqf
+++ b/addons/ai/functions/fnc_waypointParadrop.sqf
@@ -16,7 +16,7 @@
  * Public: No
  */
 
-#define MOVE_DELAY 3
+#define MOVE_DELAY 2
 #define OFFSET_DISTANCE 2000
 #define TIME_PER_UNIT 1.2
 
@@ -37,16 +37,16 @@ private _skill = skill _driver;
 _driver setSkill 1;
 _driver allowFleeing 0;
 
-private "_position";
+private ["_position", "_passengers"];
 private _nextMove = CBA_missionTime;
 
 waitUntil {
-    // Periodically issue move commands to 2 km past the waypoint's position
+    // Periodically issue move commands past the waypoint's position
     // Makes the aircraft fly over the waypoint's position and not stop at it
     if (CBA_missionTime >= _nextMove) then {
         private _direction = _vehicle getDir _waypointPosition;
         _position = _waypointPosition getPos [OFFSET_DISTANCE, _direction];
-        _vehicle move _position;
+        _vehicle doMove _position;
 
         _nextMove = CBA_missionTime + MOVE_DELAY;
     };
@@ -55,11 +55,14 @@ waitUntil {
 
     // Check if the aircraft is close enough to the waypoint to begin paradropping
     // Distance is based on the current speed of aircraft and the number of passengers
-    private _passengers = {assignedVehicleRole _x select 0 == "cargo"} count crew _vehicle;
+    _passengers = {assignedVehicleRole _x select 0 == "cargo"} count crew _vehicle;
     _vehicle distance2D _position < vectorMagnitude velocity _vehicle * TIME_PER_UNIT * _passengers / 2 + OFFSET_DISTANCE
 };
 
 [_vehicle] call EFUNC(common,ejectPassengers);
+
+// Allow units to jump out before finishing the waypoint
+sleep (TIME_PER_UNIT * _passengers + 5);
 
 _driver setSkill _skill;
 

--- a/addons/ai/functions/fnc_waypointParadrop.sqf
+++ b/addons/ai/functions/fnc_waypointParadrop.sqf
@@ -37,7 +37,7 @@ private _skill = skill _driver;
 _driver setSkill 1;
 _driver allowFleeing 0;
 
-private ["_position", "_passengers"];
+private ["_position", "_passengerCount"];
 private _nextMove = CBA_missionTime;
 
 waitUntil {
@@ -55,14 +55,14 @@ waitUntil {
 
     // Check if the aircraft is close enough to the waypoint to begin paradropping
     // Distance is based on the current speed of aircraft and the number of passengers
-    _passengers = {assignedVehicleRole _x select 0 == "cargo"} count crew _vehicle;
-    _vehicle distance2D _position < vectorMagnitude velocity _vehicle * TIME_PER_UNIT * _passengers / 2 + OFFSET_DISTANCE
+    _passengerCount = {assignedVehicleRole _x select 0 == "cargo"} count crew _vehicle;
+    _vehicle distance2D _position < vectorMagnitude velocity _vehicle * TIME_PER_UNIT * _passengerCount / 2 + OFFSET_DISTANCE
 };
 
 [_vehicle] call EFUNC(common,ejectPassengers);
 
 // Allow units to jump out before finishing the waypoint
-sleep (TIME_PER_UNIT * _passengers + 5);
+sleep (TIME_PER_UNIT * _passengerCount + 5);
 
 _driver setSkill _skill;
 

--- a/addons/ai/functions/fnc_waypointParadrop.sqf
+++ b/addons/ai/functions/fnc_waypointParadrop.sqf
@@ -55,7 +55,7 @@ waitUntil {
 
     // Check if the aircraft is close enough to the waypoint to begin paradropping
     // Distance is based on the current speed of aircraft and the number of passengers
-    _passengerCount = {assignedVehicleRole _x select 0 == "cargo"} count crew _vehicle;
+    _passengerCount = {(assignedVehicleRole _x) select 0 == "cargo"} count crew _vehicle;
     _vehicle distance2D _position < vectorMagnitude velocity _vehicle * TIME_PER_UNIT * _passengerCount / 2 + OFFSET_DISTANCE
 };
 

--- a/addons/modules/functions/fnc_moduleSpawnReinforcements.sqf
+++ b/addons/modules/functions/fnc_moduleSpawnReinforcements.sqf
@@ -126,10 +126,11 @@ if (_despawnVehicle) then {
 } else {
     // Otherwise make aircraft stay around the LZ and provide air support
     if (_isAir) then {
-        private _waypoint = _vehicleGroup addWaypoint [_positionLZ, WAYPOINT_RADIUS];
-        _waypoint setWaypointType "SAD";
-        _waypoint setWaypointBehaviour "AWARE";
-        _waypoint setWaypointCombatMode "RED";
+        private _statement = format ["private _waypoint = group this addWaypoint [%1, %2];", _positionLZ, WAYPOINT_RADIUS];
+        _statement = _statement + "_waypoint setWaypointType 'SAD'; _waypoint setWaypointBehaviour 'AWARE'; _waypoint setWaypointCombatMode 'RED'";
+
+        // Add waypoint after insertion waypoint completes to avoid issue with seek and destroy waypoints causing aircraft to slow down
+        _waypoint setWaypointStatements ["true", _statement];
     };
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- title, SAD waypoint makes aircraft slow down when approaching previous waypoint, adding the SAD waypoint after the insertion one completes seems like the most reliable way to avoid this issue
- Close #262 
