### PR TITLE
Improve markers tree selected picture color

### DIFF
--- a/addons/markers_tree/RscDisplayCurator.hpp
+++ b/addons/markers_tree/RscDisplayCurator.hpp
@@ -15,6 +15,7 @@ class RscDisplayCurator {
                 class ADDON: CreateUnitsWest {
                     idc = IDC_MARKERS_TREE;
                     idcSearch = IDC_RSCDISPLAYCURATOR_CREATE_SEARCH;
+                    colorPictureSelected[] = {1, 1, 1, 1};
                 };
             };
         };


### PR DESCRIPTION
**When merged this pull request will:**
- title, makes, for example, flag markers shown in color instead of black when selected