### PR TITLE
Move editor settings under own subcategory

### DIFF
--- a/addons/camera/initSettings.sqf
+++ b/addons/camera/initSettings.sqf
@@ -2,7 +2,7 @@
     QGVAR(followTerrain),
     "CHECKBOX",
     [LSTRING(FollowTerrain), LSTRING(FollowTerrain_Description)],
-    [ELSTRING(common,Category), LSTRING(Camera)],
+    [ELSTRING(main,DisplayName), LSTRING(DisplayName)],
     true,
     false
 ] call CBA_settings_fnc_init;
@@ -11,7 +11,7 @@
     QGVAR(adaptiveSpeed),
     "CHECKBOX",
     [LSTRING(AdaptiveSpeed), LSTRING(AdaptiveSpeed_Description)],
-    [ELSTRING(common,Category), LSTRING(Camera)],
+    [ELSTRING(main,DisplayName), LSTRING(DisplayName)],
     true,
     false
 ] call CBA_settings_fnc_init;
@@ -20,7 +20,7 @@
     QGVAR(defaultSpeedCoef),
     "SLIDER",
     [LSTRING(DefaultSpeedCoef), LSTRING(DefaultSpeedCoef_Description)],
-    [ELSTRING(common,Category), LSTRING(Camera)],
+    [ELSTRING(main,DisplayName), LSTRING(DisplayName)],
     [0.1, 5, 1, 2],
     false
 ] call CBA_settings_fnc_init;
@@ -29,7 +29,7 @@
     QGVAR(fastSpeedCoef),
     "SLIDER",
     [LSTRING(FastSpeedCoef), LSTRING(FastSpeedCoef_Description)],
-    [ELSTRING(common,Category), LSTRING(Camera)],
+    [ELSTRING(main,DisplayName), LSTRING(DisplayName)],
     [0.1, 5, 1, 2],
     false
 ] call CBA_settings_fnc_init;

--- a/addons/camera/stringtable.xml
+++ b/addons/camera/stringtable.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="ZEN">
     <Package name="Camera">
-        <Key ID="STR_ZEN_Camera_Camera">
+        <Key ID="STR_ZEN_Camera_DisplayName">
             <English>Camera</English>
             <Russian>Камера</Russian>
             <French>Caméra</French>

--- a/addons/common/initSettings.sqf
+++ b/addons/common/initSettings.sqf
@@ -2,7 +2,7 @@
     QGVAR(autoAddObjects),
     "CHECKBOX",
     [LSTRING(AutoAddObjects), LSTRING(AutoAddObjects_Description)],
-    LSTRING(Category),
+    ELSTRING(main,DisplayName),
     false,
     true
 ] call CBA_settings_fnc_init;
@@ -11,7 +11,7 @@
     QGVAR(disableGearAnim),
     "CHECKBOX",
     [LSTRING(DisableGearAnim), LSTRING(DisableGearAnim_Description)],
-    LSTRING(Category),
+    ELSTRING(main,DisplayName),
     false,
     false
 ] call CBA_settings_fnc_init;
@@ -20,7 +20,7 @@
     QGVAR(darkMode),
     "CHECKBOX",
     [LSTRING(DarkMode), LSTRING(DarkMode_Description)],
-    LSTRING(Category),
+    ELSTRING(main,DisplayName),
     false,
     false
 ] call CBA_settings_fnc_init;
@@ -29,7 +29,7 @@
     QGVAR(preferredArsenal),
     "LIST",
     [LSTRING(PreferredArsenal), LSTRING(PreferredArsenal_Description)],
-    LSTRING(Category),
+    ELSTRING(main,DisplayName),
     [[0, 1], [LSTRING(BIVirtualArsenal), LSTRING(AceArsenal)], 1],
     false
 ] call CBA_settings_fnc_init;

--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="ZEN">
     <Package name="Common">
-        <Key ID="STR_ZEN_Common_Category">
-            <English>Zeus Enhanced</English>
-            <German>Zeus Enhanced</German>
-            <Polish>Zeus Enhanced</Polish>
-            <Czech>Zeus vylepšený</Czech>
-            <Italian>Zeus Enhanced</Italian>
-            <Japanese>Zeus Enhanced</Japanese>
-        </Key>
         <Key ID="STR_ZEN_Common_Enabled">
             <English>Enabled</English>
             <Czech>Povoleno</Czech>

--- a/addons/context_menu/initKeybinds.sqf
+++ b/addons/context_menu/initKeybinds.sqf
@@ -1,4 +1,4 @@
-[ELSTRING(common,Category), QGVAR(openKey), LSTRING(OpenContextMenu), {
+[ELSTRING(main,DisplayName), QGVAR(openKey), LSTRING(OpenContextMenu), {
     if (GVAR(enabled) > 0 && {!isNull curatorCamera} && {!GETMVAR(RscDisplayCurator_search,false)}) then {
         // Cancel currently active placement
         if (call EFUNC(common,isPlacementActive)) then {

--- a/addons/context_menu/initSettings.sqf
+++ b/addons/context_menu/initSettings.sqf
@@ -2,7 +2,7 @@
     QGVAR(enabled),
     "LIST",
     [LSTRING(Enabled), LSTRING(Enabled_Description)],
-    ELSTRING(common,Category),
+    ELSTRING(main,DisplayName),
     [[0, 1, 2], [ELSTRING(common,Disabled), LSTRING(KeybindOnly), LSTRING(KeybindAndMouse)], 2],
     false
 ] call CBA_settings_fnc_init;

--- a/addons/editor/initKeybinds.sqf
+++ b/addons/editor/initKeybinds.sqf
@@ -1,4 +1,4 @@
-[ELSTRING(common,Category), QGVAR(toggleIncludeCrew), LSTRING(ToggleIncludeCrew), {
+[ELSTRING(main,DisplayName), QGVAR(toggleIncludeCrew), LSTRING(ToggleIncludeCrew), {
     if (!isNull curatorCamera && {!GETMVAR(RscDisplayCurator_search,false)}) then {
         GVAR(includeCrew) = !GVAR(includeCrew);
 
@@ -7,7 +7,7 @@
     };
 }, {}, [DIK_B, [false, false, false]]] call CBA_fnc_addKeybind; // Default: B
 
-[ELSTRING(common,Category), QGVAR(deployCountermeasures), [LSTRING(DeployCountermeasures), LSTRING(DeployCountermeasures_Description)], {
+[ELSTRING(main,DisplayName), QGVAR(deployCountermeasures), [LSTRING(DeployCountermeasures), LSTRING(DeployCountermeasures_Description)], {
     if (!isNull curatorCamera && {!GETMVAR(RscDisplayCurator_search,false)}) then {
         {
             [_x] call EFUNC(common,deployCountermeasures);
@@ -17,7 +17,7 @@
     };
 }, {}, [DIK_C, [true, false, false]]] call CBA_fnc_addKeybind; // Default: SHIFT + C
 
-[ELSTRING(common,Category), QGVAR(ejectPassengers), [LSTRING(EjectPassengers), LSTRING(EjectPassengers_Description)], {
+[ELSTRING(main,DisplayName), QGVAR(ejectPassengers), [LSTRING(EjectPassengers), LSTRING(EjectPassengers_Description)], {
     if (!isNull curatorCamera && {!GETMVAR(RscDisplayCurator_search,false)}) then {
         {
             [_x] call EFUNC(common,ejectPassengers);
@@ -27,7 +27,7 @@
     };
 }, {}, [DIK_G, [false, true, false]]] call CBA_fnc_addKeybind; // Default: CTRL + G
 
-[ELSTRING(common,Category), QGVAR(deepCopy), [LSTRING(DeepCopy), LSTRING(DeepCopy_Description)], {
+[ELSTRING(main,DisplayName), QGVAR(deepCopy), [LSTRING(DeepCopy), LSTRING(DeepCopy_Description)], {
     if (!isNull curatorCamera && {!GETMVAR(RscDisplayCurator_search,false)}) then {
         GVAR(clipboard) = [SELECTED_OBJECTS] call FUNC(deepCopy);
         playSound ["RscDisplayCurator_error01", true];
@@ -36,7 +36,7 @@
     };
 }, {}, [DIK_C, [true, true, false]]] call CBA_fnc_addKeybind; // Default: CTRL + SHIFT + C
 
-[ELSTRING(common,Category), QGVAR(deepPaste), [LSTRING(DeepPaste), LSTRING(DeepPaste_Description)], {
+[ELSTRING(main,DisplayName), QGVAR(deepPaste), [LSTRING(DeepPaste), LSTRING(DeepPaste_Description)], {
     if (!isNull curatorCamera && {!GETMVAR(RscDisplayCurator_search,false)}) then {
         [QGVAR(deepPaste), GVAR(clipboard)] call CBA_fnc_serverEvent;
         playSound ["RscDisplayCurator_error01", true];
@@ -45,7 +45,7 @@
     };
 }, {}, [DIK_V, [true, true, false]]] call CBA_fnc_addKeybind; // Default: CTRL + SHIFT + V
 
-[ELSTRING(common,Category), QGVAR(focusSearchBar), [LSTRING(FocusSearchBar), LSTRING(FocusSearchBar_Description)], {
+[ELSTRING(main,DisplayName), QGVAR(focusSearchBar), [LSTRING(FocusSearchBar), LSTRING(FocusSearchBar_Description)], {
     if (!isNull curatorCamera && {!GETMVAR(RscDisplayCurator_search,false)}) then {
         private _searchIDC = [IDC_RSCDISPLAYCURATOR_CREATE_SEARCH, IDC_SEARCH_CUSTOM] select GVAR(disableLiveSearch);
         private _ctrlSearch = findDisplay IDD_RSCDISPLAYCURATOR displayCtrl _searchIDC;
@@ -53,7 +53,7 @@
     };
 }, {}, [DIK_F, [false, true, true]]] call CBA_fnc_addKeybind; // Default: CTRL + ALT + F
 
-[ELSTRING(common,Category), QGVAR(toggleIcons), [LSTRING(ToggleIcons), LSTRING(ToggleIcons_Description)], {
+[ELSTRING(main,DisplayName), QGVAR(toggleIcons), [LSTRING(ToggleIcons), LSTRING(ToggleIcons_Description)], {
     if (!isNull curatorCamera && {!GETMVAR(RscDisplayCurator_search,false)}) then {
         GVAR(iconsVisible) = !GVAR(iconsVisible);
 

--- a/addons/editor/initSettings.sqf
+++ b/addons/editor/initSettings.sqf
@@ -2,7 +2,7 @@
     QGVAR(moveDisplayToEdge),
     "CHECKBOX",
     [LSTRING(MoveDisplayToEdge), LSTRING(MoveDisplayToEdge_Description)],
-    ELSTRING(common,Category),
+    [ELSTRING(main,DisplayName), LSTRING(DisplayName)],
     true,
     false
 ] call CBA_settings_fnc_init;
@@ -11,7 +11,7 @@
     QGVAR(removeWatermark),
     "CHECKBOX",
     [LSTRING(RemoveWatermark), LSTRING(RemoveWatermark_Description)],
-    ELSTRING(common,Category),
+    [ELSTRING(main,DisplayName), LSTRING(DisplayName)],
     true,
     false
 ] call CBA_settings_fnc_init;
@@ -20,7 +20,7 @@
     QGVAR(disableLiveSearch),
     "CHECKBOX",
     [LSTRING(DisableLiveSearch), LSTRING(DisableLiveSearch_Description)],
-    ELSTRING(common,Category),
+    [ELSTRING(main,DisplayName), LSTRING(DisplayName)],
     false,
     false
 ] call CBA_settings_fnc_init;
@@ -29,7 +29,7 @@
     QGVAR(declutterEmptyTree),
     "CHECKBOX",
     [LSTRING(DeclutterEmptyTree), LSTRING(DeclutterEmptyTree_Description)],
-    ELSTRING(common,Category),
+    [ELSTRING(main,DisplayName), LSTRING(DisplayName)],
     true,
     false
 ] call CBA_settings_fnc_init;
@@ -38,7 +38,7 @@
     QGVAR(addGroupIcons),
     "CHECKBOX",
     [LSTRING(AddGroupIcons), LSTRING(AddGroupIcons_Description)],
-    ELSTRING(common,Category),
+    [ELSTRING(main,DisplayName), LSTRING(DisplayName)],
     false,
     false
 ] call CBA_settings_fnc_init;
@@ -47,7 +47,7 @@
     QGVAR(unitRadioMessages),
     "LIST",
     [LSTRING(UnitRadioMessages), LSTRING(UnitRadioMessages_Description)],
-    ELSTRING(common,Category),
+    [ELSTRING(main,DisplayName), LSTRING(DisplayName)],
     [[0, 1, 2], [ELSTRING(common,Enabled), LSTRING(UnitRadioMessages_WaypointsOnly), ELSTRING(common,Disabled)], 0],
     false
 ] call CBA_settings_fnc_init;
@@ -56,7 +56,7 @@
     QGVAR(parachuteSounds),
     "CHECKBOX",
     [LSTRING(ParachuteSounds), LSTRING(ParachuteSounds_Description)],
-    ELSTRING(common,Category),
+    [ELSTRING(main,DisplayName), LSTRING(DisplayName)],
     true,
     true
 ] call CBA_settings_fnc_init;

--- a/addons/editor/stringtable.xml
+++ b/addons/editor/stringtable.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="ZEN">
     <Package name="Editor">
+        <Key ID="STR_ZEN_Editor_DisplayName">
+            <English>Editor</English>
+        </Key>
         <Key ID="STR_ZEN_Editor_MoveDisplayToEdge">
             <English>Move Display to Edge</English>
             <French>Déplacer l'affichage sur le bord</French>

--- a/addons/editor_previews/initSettings.sqf
+++ b/addons/editor_previews/initSettings.sqf
@@ -2,7 +2,7 @@
     QGVAR(enabled),
     "CHECKBOX",
     [LSTRING(Enabled), LSTRING(Enabled_Description)],
-    ELSTRING(common,Category),
+    [ELSTRING(main,DisplayName), ELSTRING(editor,DisplayName)],
     true,
     false
 ] call CBA_settings_fnc_init;

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -1,13 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="ZEN">
     <Package name="Main">
+        <Key ID="STR_ZEN_Main_DisplayName">
+            <English>Zeus Enhanced</English>
+            <German>Zeus Enhanced</German>
+            <Polish>Zeus Enhanced</Polish>
+            <Portuguese>Zeus Enhanced</Portuguese>
+            <Russian>Zeus Enhanced</Russian>
+            <Czech>Zeus Enhanced</Czech>
+            <Spanish>Zeus Enhanced</Spanish>
+            <Italian>Zeus Enhanced</Italian>
+            <French>Zeus Enhanced</French>
+            <Korean>Zeus Enhanced</Korean>
+            <Japanese>Zeus Enhanced</Japanese>
+            <Chinese>Zeus Enhanced</Chinese>
+            <Chinesesimp>Zeus Enhanced</Chinesesimp>
+        </Key>
         <Key ID="STR_ZEN_Main_Author">
             <English>ZEN Team</English>
-            <French>ZEN Team</French>
             <German>ZEN Team</German>
             <Polish>ZEN Team</Polish>
+            <Portuguese>ZEN Team</Portuguese>
+            <Russian>ZEN Team</Russian>
+            <Czech>ZEN Team</Czech>
+            <Spanish>ZEN Team</Spanish>
             <Italian>ZEN Team</Italian>
-            <Japanese>ZEN チーム</Japanese>
+            <French>ZEN Team</French>
+            <Korean>ZEN Team</Korean>
+            <Japanese>ZEN Team</Japanese>
+            <Chinese>ZEN Team</Chinese>
+            <Chinesesimp>ZEN Team</Chinesesimp>
         </Key>
         <Key ID="STR_ZEN_Main_URL">
             <English>https://github.com/zen-mod/ZEN</English>

--- a/addons/placement/initSettings.sqf
+++ b/addons/placement/initSettings.sqf
@@ -2,7 +2,7 @@
     QGVAR(enabled),
     "CHECKBOX",
     [LSTRING(Enabled), LSTRING(Enabled_Description)],
-    ELSTRING(common,Category),
+    ELSTRING(main,DisplayName),
     false,
     false,
     {

--- a/addons/visibility/initSettings.sqf
+++ b/addons/visibility/initSettings.sqf
@@ -2,7 +2,7 @@
     QGVAR(enabled),
     "CHECKBOX",
     [LSTRING(Enabled), LSTRING(Enabled_Description)],
-    ELSTRING(common,Category),
+    ELSTRING(main,DisplayName),
     false,
     false,
     {

--- a/addons/vision/initKeybinds.sqf
+++ b/addons/vision/initKeybinds.sqf
@@ -1,11 +1,11 @@
-[ELSTRING(common,Category), QGVAR(increaseNVGBrightness), LSTRING(IncreaseNVGBrightness), {
+[ELSTRING(main,DisplayName), QGVAR(increaseNVGBrightness), LSTRING(IncreaseNVGBrightness), {
     if (isNull curatorCamera || {!ppEffectEnabled GVAR(ppBrightness)}) exitWith {false};
 
     [1] call FUNC(changeBrightness);
     true
 }, {}, [DIK_PGUP, [false, false, true]]] call CBA_fnc_addKeybind; // Default: ALT + Page Up
 
-[ELSTRING(common,Category), QGVAR(decreaseNVGBrightness), LSTRING(DecreaseNVGBrightness), {
+[ELSTRING(main,DisplayName), QGVAR(decreaseNVGBrightness), LSTRING(DecreaseNVGBrightness), {
     if (isNull curatorCamera || {!ppEffectEnabled GVAR(ppBrightness)}) exitWith {false};
 
     [-1] call FUNC(changeBrightness);

--- a/addons/vision/initSettings.sqf
+++ b/addons/vision/initSettings.sqf
@@ -2,7 +2,7 @@
     QGVAR(enableNVG),
     "CHECKBOX",
     LSTRING(EnableNVG),
-    [ELSTRING(common,Category), LSTRING(VisionModes)],
+    [ELSTRING(main,DisplayName), LSTRING(DisplayName)],
     true,
     false
 ] call CBA_settings_fnc_init;
@@ -11,7 +11,7 @@
     QGVAR(enableWhiteHot),
     "CHECKBOX",
     LSTRING(EnableWhiteHot),
-    [ELSTRING(common,Category), LSTRING(VisionModes)],
+    [ELSTRING(main,DisplayName), LSTRING(DisplayName)],
     true,
     false
 ] call CBA_settings_fnc_init;
@@ -20,7 +20,7 @@
     QGVAR(enableBlackHot),
     "CHECKBOX",
     LSTRING(EnableBlackHot),
-    [ELSTRING(common,Category), LSTRING(VisionModes)],
+    [ELSTRING(main,DisplayName), LSTRING(DisplayName)],
     false,
     false
 ] call CBA_settings_fnc_init;
@@ -29,7 +29,7 @@
     QGVAR(enableGreenHotCold),
     "CHECKBOX",
     LSTRING(EnableGreenHotCold),
-    [ELSTRING(common,Category), LSTRING(VisionModes)],
+    [ELSTRING(main,DisplayName), LSTRING(DisplayName)],
     false,
     false
 ] call CBA_settings_fnc_init;
@@ -38,7 +38,7 @@
     QGVAR(enableBlackHotGreenCold),
     "CHECKBOX",
     LSTRING(EnableBlackHotGreenCold),
-    [ELSTRING(common,Category), LSTRING(VisionModes)],
+    [ELSTRING(main,DisplayName), LSTRING(DisplayName)],
     false,
     false
 ] call CBA_settings_fnc_init;
@@ -47,7 +47,7 @@
     QGVAR(enableRedHotCold),
     "CHECKBOX",
     LSTRING(EnableRedHotCold),
-    [ELSTRING(common,Category), LSTRING(VisionModes)],
+    [ELSTRING(main,DisplayName), LSTRING(DisplayName)],
     false,
     false
 ] call CBA_settings_fnc_init;
@@ -56,7 +56,7 @@
     QGVAR(enableBlackHotRedCold),
     "CHECKBOX",
     LSTRING(EnableBlackHotRedCold),
-    [ELSTRING(common,Category), LSTRING(VisionModes)],
+    [ELSTRING(main,DisplayName), LSTRING(DisplayName)],
     false,
     false
 ] call CBA_settings_fnc_init;
@@ -65,7 +65,7 @@
     QGVAR(enableWhiteHotRedCold),
     "CHECKBOX",
     LSTRING(EnableWhiteHotRedCold),
-    [ELSTRING(common,Category), LSTRING(VisionModes)],
+    [ELSTRING(main,DisplayName), LSTRING(DisplayName)],
     false,
     false
 ] call CBA_settings_fnc_init;
@@ -74,7 +74,7 @@
     QGVAR(enableRedGreenThermal),
     "CHECKBOX",
     LSTRING(EnableRedGreenThermal),
-    [ELSTRING(common,Category), LSTRING(VisionModes)],
+    [ELSTRING(main,DisplayName), LSTRING(DisplayName)],
     false,
     false
 ] call CBA_settings_fnc_init;

--- a/addons/vision/stringtable.xml
+++ b/addons/vision/stringtable.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="ZEN">
     <Package name="Vision">
-        <Key ID="STR_ZEN_Vision_VisionModes">
+        <Key ID="STR_ZEN_Vision_DisplayName">
             <English>Vision Modes</English>
             <French>Mode de vision</French>
             <Russian>Режимы зрения</Russian>


### PR DESCRIPTION
**When merged this pull request will:**
- Move `editor` and `editor_previews` settings under their own subcategory - "Editor"
    - Makes the settings menu a bit more organized
- Move mod display name from `common` to `main`
