### PR TITLE
Fix flashlight keybind category

### DIFF
--- a/addons/flashlight/initKeybinds.sqf
+++ b/addons/flashlight/initKeybinds.sqf
@@ -1,4 +1,4 @@
-[ELSTRING(common,Category), QGVAR(toggle), [LSTRING(Toggle), LSTRING(Toggle_Description)], {
+[ELSTRING(main,DisplayName), QGVAR(toggle), [LSTRING(Toggle), LSTRING(Toggle_Description)], {
     if (!isNull curatorCamera && {!GETMVAR(RscDisplayCurator_search,false)}) then {
         GVAR(state) = !GVAR(state);
         GVAR(state) call FUNC(toggle);


### PR DESCRIPTION
**When merged this pull request will:**
- title, caused by moving strings to `main` in #308 
