### PR TITLE
Fix Bind Variable module broadcast option

### DIFF
--- a/addons/modules/functions/fnc_moduleBindVariable.sqf
+++ b/addons/modules/functions/fnc_moduleBindVariable.sqf
@@ -25,11 +25,11 @@ if (isNull _object) exitWith {
 };
 
 [LSTRING(BindVariable), [
-    ["EDIT", LSTRING(VariableName)],
-    ["TOOLBOX:YESNO", LSTRING(PublicVariable)]
+    ["EDIT", LSTRING(VariableName), ""],
+    ["TOOLBOX:YESNO", LSTRING(BroadcastVariable), false]
 ], {
-    params ["_dialogValues", "_object"];
-    _dialogValues params ["_variableName", "_isPublic"];
+    params ["_values", "_object"];
+    _values params ["_variableName", "_isPublic"];
 
     if (_variableName == "") exitWith {};
 

--- a/addons/modules/stringtable.xml
+++ b/addons/modules/stringtable.xml
@@ -490,7 +490,7 @@
             <Polish>Nazwa zmiennej</Polish>
             <Japanese>変数名</Japanese>
         </Key>
-        <Key ID="STR_ZEN_Modules_PublicVariable">
+        <Key ID="STR_ZEN_Modules_BroadcastVariable">
             <English>Public (Broadcast)</English>
             <German>Öffentlich (Übertragung)</German>
             <Polish>Zmienna publiczna</Polish>


### PR DESCRIPTION
**When merged this pull request will:**
- title, `TOOLBOX` defaults to a number not bool
- Close #325 