### PR TITLE
Add ability for VLS to track targets

### DIFF
--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -11,6 +11,7 @@ PREP(earthquake);
 PREP(ejectPassengers);
 PREP(exportMissionSQF);
 PREP(exportText);
+PREP(fireArtillery);
 PREP(fireVLS);
 PREP(getActiveTree);
 PREP(getAllTurrets);

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -272,6 +272,7 @@
 }] call CBA_fnc_addEventHandler;
 
 [QGVAR(earthquake), LINKFUNC(earthquake)] call CBA_fnc_addEventHandler;
+[QGVAR(fireArtillery), LINKFUNC(fireArtillery)] call CBA_fnc_addEventHandler;
 [QGVAR(setLampState), LINKFUNC(setLampState)] call CBA_fnc_addEventHandler;
 [QGVAR(setMagazineAmmo), LINKFUNC(setMagazineAmmo)] call CBA_fnc_addEventHandler;
 [QGVAR(setTurretAmmo), LINKFUNC(setTurretAmmo)] call CBA_fnc_addEventHandler;

--- a/addons/common/functions/fnc_fireArtillery.sqf
+++ b/addons/common/functions/fnc_fireArtillery.sqf
@@ -1,0 +1,55 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Makes the given artillery unit fire on the given position.
+ *
+ * Arguments:
+ * 0: Artillery Unit <OBJECT>
+ * 1: Position <ARRAY|OBJECT|STRING>
+ *   - in AGL format, or a Map Grid when STRING
+ * 2: Spread <NUMBER>
+ * 3: Magazine <STRING>
+ * 4: Number of Rounds <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [_unit, _position, 0, _magazine, 1] call zen_common_fnc_fireArtillery
+ *
+ * Public: No
+ */
+
+#define LOW_SPREAD_THRESHOLD 25
+
+params [["_unit", objNull, [objNull]], ["_position", [0, 0, 0], [[], objNull, ""], 3], ["_spread", 0, [0]], ["_magazine", "", [""]], ["_rounds", 1, [0]]];
+
+if (_unit call EFUNC(common,isVLS)) exitWith {
+    _this call EFUNC(common,fireVLS);
+};
+
+if (_position isEqualType objNull) then {
+    _position = ASLtoAGL getPosASL _position;
+};
+
+if (_position isEqualType "") then {
+    _position = [_position, true] call CBA_fnc_mapGridToPos;
+};
+
+// For small spread values, use doArtilleryFire directly to avoid delay
+// between firing caused by using doArtilleryFire one round at a time
+if (_spread <= LOW_SPREAD_THRESHOLD) exitWith {
+    _unit doArtilleryFire [_position, _magazine, _rounds];
+};
+
+[{
+    params ["_unit", "_position", "_spread", "_magazine", "_rounds"];
+
+    if (unitReady _unit) then {
+        _unit doArtilleryFire [[_position, _spread] call CBA_fnc_randPos, _magazine, 1];
+        _rounds = _rounds - 1;
+        _this set [4, _rounds];
+    };
+
+    _rounds <= 0 || {!alive _unit} || {!alive gunner _unit}
+}, {}, [_unit, _position, _spread, _magazine, _rounds]] call CBA_fnc_waitUntilAndExecute;

--- a/addons/common/functions/fnc_getArtilleryETA.sqf
+++ b/addons/common/functions/fnc_getArtilleryETA.sqf
@@ -6,7 +6,8 @@
  *
  * Arguments:
  * 0: Vehicle <OBJECT>
- * 1: Position <ARRAY>
+ * 1: Position <ARRAY|OBJECT|STRING>
+ *   - in AGL format, or a Map Grid when STRING
  * 2: Magazine <STRING>
  *
  * Return Value:
@@ -25,7 +26,15 @@
 // The max speed of the missile is approximately 94% of the config defined max speed
 #define SPEED_COEFFICIENT 0.94
 
-params [["_vehicle", objNull, [objNull]], ["_position", [0, 0, 0], [[]], 3], ["_magazine", "", [""]]];
+params [["_vehicle", objNull, [objNull]], ["_position", [0, 0, 0], [[], objNull, ""], 3], ["_magazine", "", [""]]];
+
+if (_position isEqualType objNull) then {
+    _position = ASLtoAGL getPosASL _position;
+};
+
+if (_position isEqualType "") then {
+    _position = [_position, true] call CBA_fnc_mapGridToPos;
+};
 
 if (_vehicle call FUNC(isVLS)) then {
     private _missileType = getText (configfile >> "CfgMagazines" >> _magazine >> "ammo");

--- a/addons/modules/XEH_postInit.sqf
+++ b/addons/modules/XEH_postInit.sqf
@@ -73,28 +73,3 @@ if (isServer) then {
         _unit setVehiclePosition [_position, [], 0, "NONE"];
     }, _this] call CBA_fnc_execNextFrame;
 }] call CBA_fnc_addEventHandler;
-
-[QGVAR(fireArtillery), {
-    params ["_unit", "_position", "_spread", "_ammo", "_rounds"];
-
-    if (_unit call EFUNC(common,isVLS)) exitWith {
-        _this call EFUNC(common,fireVLS);
-    };
-
-    // For small spread values, use doArtilleryFire directly to avoid delay
-    // between firing caused by using doArtilleryFire one round at a time
-    if (_spread <= 10) exitWith {
-        _unit doArtilleryFire [_position, _ammo, _rounds];
-    };
-
-    [{
-        params ["_unit", "_position", "_spread", "_ammo", "_rounds", "_fired"];
-
-        if (unitReady _unit) then {
-            _unit doArtilleryFire [[_position, _spread] call CBA_fnc_randPos, _ammo, 1];
-            _this set [5, _fired + 1];
-        };
-
-        _fired >= _rounds || {!alive _unit} || {!alive gunner _unit}
-    }, {}, [_unit, _position, _spread, _ammo, _rounds, 0]] call CBA_fnc_waitUntilAndExecute;
-}] call CBA_fnc_addEventHandler;

--- a/addons/modules/functions/fnc_moduleFireMission.sqf
+++ b/addons/modules/functions/fnc_moduleFireMission.sqf
@@ -8,7 +8,7 @@
  * 1: Target Grid or Logic <STRING|OBJECT>
  * 2: Spread <NUMBER>
  * 3: Ammo Magazine <STRING>
- * 4: Rounds To Fire <NUMBER>
+ * 4: Number of Rounds <NUMBER>
  *
  * Return Value:
  * None
@@ -19,22 +19,18 @@
  * Public: No
  */
 
-params ["_vehicles", "_target", "_spread", "_ammo", "_rounds"];
+params ["_vehicles", "_target", "_spread", "_magazine", "_rounds"];
 
-private _position = if (_target isEqualType "") then {
-    [_target, true] call CBA_fnc_mapGridToPos
-} else {
-    ASLtoAGL getPosASL _target
-};
-
-private _eta = selectMin (_vehicles apply {[_x, _position, _ammo] call EFUNC(common,getArtilleryETA)});
+private _eta = selectMin (_vehicles apply {
+    [_x, _target, _magazine] call EFUNC(common,getArtilleryETA);
+});
 
 if (_eta == -1) exitWith {
     [LSTRING(NotInRangeOfArtillery)] call EFUNC(common,showMessage);
 };
 
 {
-    [QGVAR(fireArtillery), [_x, _position, _spread, _ammo, _rounds], _x] call CBA_fnc_targetEvent;
+    [QEGVAR(common,fireArtillery), [_x, _target, _spread, _magazine, _rounds], _x] call CBA_fnc_targetEvent;
 } forEach _vehicles;
 
 [LSTRING(ModuleFireMission_ArtilleryETA), _eta toFixed 1] call EFUNC(common,showMessage);

--- a/addons/modules/stringtable.xml
+++ b/addons/modules/stringtable.xml
@@ -1934,9 +1934,9 @@
             <Chinese>最近的房子離太遠了</Chinese>
         </Key>
         <Key ID="STR_ZEN_Modules_NoTargetModules">
-            <English>No target modules exist, place one first</English>
-            <German>Es gibt keine Zielmodule, platzieren Sie zuerst ein Zielmodul</German>
-            <Polish>Brak modułów celu, najpierw ustaw moduł celu</Polish>
+            <English>No target modules exist, place one first.</English>
+            <German>Es gibt keine Zielmodule, platzieren Sie zuerst ein Zielmodul.</German>
+            <Polish>Brak modułów celu, najpierw ustaw moduł celu.</Polish>
             <Japanese>モジュールの目標が無い為、何か設置して下さい。</Japanese>
         </Key>
         <Key ID="STR_ZEN_Modules_NotInRangeOfArtillery">


### PR DESCRIPTION
**When merged this pull request will:**
- Add ability for VLS to track moving targets, Close #320 
- Add common `fireArtillery` function
    - Mostly moved code from `modules` event
- Improve artillery related functions (`fireArtillery, `fireVLS`, `getArtilleryETA`) to handle objects and map grid strings being passed as positions
- Increase low spread threshold from 10 to 25

