### PR TITLE
Fix placement preview preventing placement using the map

### DIFF
--- a/addons/placement/functions/fnc_handleObjectPlaced.sqf
+++ b/addons/placement/functions/fnc_handleObjectPlaced.sqf
@@ -16,7 +16,8 @@
  * Public: No
  */
 
-if (!GVAR(enabled)) exitWith {};
+// Exit if placement preview is disabled or objects were placed using the map
+if (!GVAR(enabled) || {visibleMap}) exitWith {};
 
 params ["", "_object"];
 


### PR DESCRIPTION
**When merged this pull request will:**
- title, disable placement preview positioning when objects are placed using the map