### PR TITLE
Fix release drafter category titles and change template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,24 +8,24 @@ categories:
   - title: '**ADDED:**'
     labels:
       - 'feature'
-  - title: '**IMPROVED**'
+  - title: '**IMPROVED:**'
     labels:
       - 'enhancement'
       - 'optimization'
-  - title: '**CHANGED**'
+  - title: '**CHANGED:**'
     labels:
       - 'cleanup'
   - title: '**FIXED:**'
     labels:
       - 'bug fix'
-  - title: '**TRANSLATIONS**'
+  - title: '**TRANSLATIONS:**'
     labels:
       - 'translation'
 
 exclude-labels:
   - 'ignore changelog'
 
-change-template: '- $TITLE ($NUMBER)'
+change-template: '- $TITLE (#$NUMBER)'
 template: |
   _Requires CBA Version X.Y.Z or later and Arma 3 Version X.Y or later._
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add colons after category titles
- Add "#" before PR numbers
