### PR TITLE
Fix preserving unit sides in deserialize objects function

### DIFF
--- a/addons/common/functions/fnc_deserializeObjects.sqf
+++ b/addons/common/functions/fnc_deserializeObjects.sqf
@@ -94,6 +94,9 @@ private _fnc_deserializeUnit = {
     _unit setUnitPos _stance;
     _unit forceFlagTexture _flagTexture;
 
+    // Ensure unit belongs to the same side as the group
+    [_unit] joinSilent _group;
+
     if (_isLeader) then {
         _group selectLeader _unit;
         _group setFormDir _direction;


### PR DESCRIPTION
**When merged this pull request will:**
- title, group had the correct side but units belonged to their original config defined one
- Close #373 
