### PR TITLE
Unlock malaria-infected civs

### DIFF
--- a/addons/characters/$PBOPREFIX$
+++ b/addons/characters/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\zen\addons\characters

--- a/addons/characters/CfgEditorSubcategories.hpp
+++ b/addons/characters/CfgEditorSubcategories.hpp
@@ -1,0 +1,5 @@
+class CfgEditorSubcategories {
+    class EdSubcat_Personnel_Sick {
+        displayName = CSTRING(MenSick);
+    };
+};

--- a/addons/characters/CfgVehicles.hpp
+++ b/addons/characters/CfgVehicles.hpp
@@ -1,0 +1,95 @@
+class CfgVehicles {
+    // External class reference
+	class C_Man_casual_1_F_afro;
+	class C_Man_casual_3_F_afro;
+	class C_Man_casual_4_F_afro;
+	class C_Man_casual_5_F_afro;
+	class C_Man_casual_6_F_afro;
+	class C_man_polo_1_F_afro;
+	class C_man_polo_2_F_afro;
+	class C_man_polo_3_F_afro;
+	class C_man_polo_6_F_afro;
+	class C_man_sport_2_F_afro;
+
+    class C_Man_casual_1_F_afro_sick : C_Man_casual_1_F_afro {
+		editorSubcategory = "EdSubcat_Personnel_Sick";
+        scope = 2;
+        scopeCurator = 2;
+        class EventHandlers {
+            init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
+        };
+    };
+    class C_Man_casual_3_F_afro_sick : C_Man_casual_3_F_afro {
+		editorSubcategory = "EdSubcat_Personnel_Sick";
+        scope = 2;
+        scopeCurator = 2;
+        class EventHandlers {
+            init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
+        };
+    };
+    class C_Man_casual_4_F_afro_sick : C_Man_casual_4_F_afro {
+		editorSubcategory = "EdSubcat_Personnel_Sick";
+        scope = 2;
+        scopeCurator = 2;
+        class EventHandlers {
+            init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
+        };
+    };
+    class C_Man_casual_5_F_afro_sick : C_Man_casual_5_F_afro {
+		editorSubcategory = "EdSubcat_Personnel_Sick";
+        scope = 2;
+        scopeCurator = 2;
+        class EventHandlers {
+            init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
+        };
+    };
+    class C_Man_casual_6_F_afro_sick : C_Man_casual_6_F_afro {
+		editorSubcategory = "EdSubcat_Personnel_Sick";
+        scope = 2;
+        scopeCurator = 2;
+        class EventHandlers {
+            init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
+        };
+    };
+    class C_man_polo_1_F_afro_sick : C_man_polo_1_F_afro {
+		editorSubcategory = "EdSubcat_Personnel_Sick";
+        scope = 2;
+        scopeCurator = 2;
+        class EventHandlers {
+            init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
+        };
+    };
+    class C_man_polo_2_F_afro_sick : C_man_polo_2_F_afro {
+		editorSubcategory = "EdSubcat_Personnel_Sick";
+        scope = 2;
+        scopeCurator = 2;
+        class EventHandlers {
+            init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
+        };
+    };
+    class C_man_polo_3_F_afro_sick : C_man_polo_3_F_afro {
+		editorSubcategory = "EdSubcat_Personnel_Sick";
+        scope = 2;
+        scopeCurator = 2;
+        class EventHandlers {
+            init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
+        };
+    };
+    class C_man_polo_6_F_afro_sick : C_man_polo_6_F_afro {
+		editorSubcategory = "EdSubcat_Personnel_Sick";
+        scope = 2;
+        scopeCurator = 2;
+        class EventHandlers {
+            init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
+        };
+    };
+    class C_man_sport_2_F_afro_sick : C_man_sport_2_F_afro {
+		editorSubcategory = "EdSubcat_Personnel_Sick";
+        scope = 2;
+        scopeCurator = 2;
+        class EventHandlers {
+            init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
+        };
+    };
+};
+

--- a/addons/characters/CfgVehicles.hpp
+++ b/addons/characters/CfgVehicles.hpp
@@ -12,93 +12,43 @@ class CfgVehicles {
     class C_man_sport_2_F_afro;
 
     class C_Man_casual_1_F_afro_sick : C_Man_casual_1_F_afro {
-        editorSubcategory = "EdSubcat_Personnel_Sick";
-        scope = 2;
-        scopeCurator = 2;
-        class EventHandlers {
-            init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
-        };
+        C_MAN_SICK_ATTRIBUTE_MODIFICATIONS
     };
 
     class C_Man_casual_3_F_afro_sick : C_Man_casual_3_F_afro {
-        editorSubcategory = "EdSubcat_Personnel_Sick";
-        scope = 2;
-        scopeCurator = 2;
-        class EventHandlers {
-            init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
-        };
+        C_MAN_SICK_ATTRIBUTE_MODIFICATIONS
     };
 
     class C_Man_casual_4_F_afro_sick : C_Man_casual_4_F_afro {
-        editorSubcategory = "EdSubcat_Personnel_Sick";
-        scope = 2;
-        scopeCurator = 2;
-        class EventHandlers {
-            init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
-        };
+        C_MAN_SICK_ATTRIBUTE_MODIFICATIONS
     };
 
     class C_Man_casual_5_F_afro_sick : C_Man_casual_5_F_afro {
-        editorSubcategory = "EdSubcat_Personnel_Sick";
-        scope = 2;
-        scopeCurator = 2;
-        class EventHandlers {
-            init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
-        };
+        C_MAN_SICK_ATTRIBUTE_MODIFICATIONS
     };
 
     class C_Man_casual_6_F_afro_sick : C_Man_casual_6_F_afro {
-        editorSubcategory = "EdSubcat_Personnel_Sick";
-        scope = 2;
-        scopeCurator = 2;
-        class EventHandlers {
-            init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
-        };
+        C_MAN_SICK_ATTRIBUTE_MODIFICATIONS
     };
 
     class C_man_polo_1_F_afro_sick : C_man_polo_1_F_afro {
-        editorSubcategory = "EdSubcat_Personnel_Sick";
-        scope = 2;
-        scopeCurator = 2;
-        class EventHandlers {
-            init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
-        };
+        C_MAN_SICK_ATTRIBUTE_MODIFICATIONS
     };
 
     class C_man_polo_2_F_afro_sick : C_man_polo_2_F_afro {
-        editorSubcategory = "EdSubcat_Personnel_Sick";
-        scope = 2;
-        scopeCurator = 2;
-        class EventHandlers {
-            init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
-        };
+        C_MAN_SICK_ATTRIBUTE_MODIFICATIONS
     };
 
     class C_man_polo_3_F_afro_sick : C_man_polo_3_F_afro {
-        editorSubcategory = "EdSubcat_Personnel_Sick";
-        scope = 2;
-        scopeCurator = 2;
-        class EventHandlers {
-            init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
-        };
+        C_MAN_SICK_ATTRIBUTE_MODIFICATIONS
     };
 
     class C_man_polo_6_F_afro_sick : C_man_polo_6_F_afro {
-        editorSubcategory = "EdSubcat_Personnel_Sick";
-        scope = 2;
-        scopeCurator = 2;
-        class EventHandlers {
-            init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
-        };
+        C_MAN_SICK_ATTRIBUTE_MODIFICATIONS
     };
 
     class C_man_sport_2_F_afro_sick : C_man_sport_2_F_afro {
-        editorSubcategory = "EdSubcat_Personnel_Sick";
-        scope = 2;
-        scopeCurator = 2;
-        class EventHandlers {
-            init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
-        };
+        C_MAN_SICK_ATTRIBUTE_MODIFICATIONS
     };
 };
 

--- a/addons/characters/CfgVehicles.hpp
+++ b/addons/characters/CfgVehicles.hpp
@@ -1,90 +1,99 @@
 class CfgVehicles {
     // External class reference
-	class C_Man_casual_1_F_afro;
-	class C_Man_casual_3_F_afro;
-	class C_Man_casual_4_F_afro;
-	class C_Man_casual_5_F_afro;
-	class C_Man_casual_6_F_afro;
-	class C_man_polo_1_F_afro;
-	class C_man_polo_2_F_afro;
-	class C_man_polo_3_F_afro;
-	class C_man_polo_6_F_afro;
-	class C_man_sport_2_F_afro;
+    class C_Man_casual_1_F_afro;
+    class C_Man_casual_3_F_afro;
+    class C_Man_casual_4_F_afro;
+    class C_Man_casual_5_F_afro;
+    class C_Man_casual_6_F_afro;
+    class C_man_polo_1_F_afro;
+    class C_man_polo_2_F_afro;
+    class C_man_polo_3_F_afro;
+    class C_man_polo_6_F_afro;
+    class C_man_sport_2_F_afro;
 
     class C_Man_casual_1_F_afro_sick : C_Man_casual_1_F_afro {
-		editorSubcategory = "EdSubcat_Personnel_Sick";
+        editorSubcategory = "EdSubcat_Personnel_Sick";
         scope = 2;
         scopeCurator = 2;
         class EventHandlers {
             init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
         };
     };
+
     class C_Man_casual_3_F_afro_sick : C_Man_casual_3_F_afro {
-		editorSubcategory = "EdSubcat_Personnel_Sick";
+        editorSubcategory = "EdSubcat_Personnel_Sick";
         scope = 2;
         scopeCurator = 2;
         class EventHandlers {
             init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
         };
     };
+
     class C_Man_casual_4_F_afro_sick : C_Man_casual_4_F_afro {
-		editorSubcategory = "EdSubcat_Personnel_Sick";
+        editorSubcategory = "EdSubcat_Personnel_Sick";
         scope = 2;
         scopeCurator = 2;
         class EventHandlers {
             init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
         };
     };
+
     class C_Man_casual_5_F_afro_sick : C_Man_casual_5_F_afro {
-		editorSubcategory = "EdSubcat_Personnel_Sick";
+        editorSubcategory = "EdSubcat_Personnel_Sick";
         scope = 2;
         scopeCurator = 2;
         class EventHandlers {
             init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
         };
     };
+
     class C_Man_casual_6_F_afro_sick : C_Man_casual_6_F_afro {
-		editorSubcategory = "EdSubcat_Personnel_Sick";
+        editorSubcategory = "EdSubcat_Personnel_Sick";
         scope = 2;
         scopeCurator = 2;
         class EventHandlers {
             init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
         };
     };
+
     class C_man_polo_1_F_afro_sick : C_man_polo_1_F_afro {
-		editorSubcategory = "EdSubcat_Personnel_Sick";
+        editorSubcategory = "EdSubcat_Personnel_Sick";
         scope = 2;
         scopeCurator = 2;
         class EventHandlers {
             init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
         };
     };
+
     class C_man_polo_2_F_afro_sick : C_man_polo_2_F_afro {
-		editorSubcategory = "EdSubcat_Personnel_Sick";
+        editorSubcategory = "EdSubcat_Personnel_Sick";
         scope = 2;
         scopeCurator = 2;
         class EventHandlers {
             init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
         };
     };
+
     class C_man_polo_3_F_afro_sick : C_man_polo_3_F_afro {
-		editorSubcategory = "EdSubcat_Personnel_Sick";
+        editorSubcategory = "EdSubcat_Personnel_Sick";
         scope = 2;
         scopeCurator = 2;
         class EventHandlers {
             init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
         };
     };
+
     class C_man_polo_6_F_afro_sick : C_man_polo_6_F_afro {
-		editorSubcategory = "EdSubcat_Personnel_Sick";
+        editorSubcategory = "EdSubcat_Personnel_Sick";
         scope = 2;
         scopeCurator = 2;
         class EventHandlers {
             init = "(_this select 0) setIdentity selectRandom ['BIS_Ambient01_sick','BIS_Ambient02_sick','BIS_Ambient03_sick','BIS_Arthur_Sick','BIS_Howard_sick','BIS_John_sick','BIS_Lucas_sick','BIS_Renly_sick']; (_this select 0) setDamage 0.45";
         };
     };
+
     class C_man_sport_2_F_afro_sick : C_man_sport_2_F_afro {
-		editorSubcategory = "EdSubcat_Personnel_Sick";
+        editorSubcategory = "EdSubcat_Personnel_Sick";
         scope = 2;
         scopeCurator = 2;
         class EventHandlers {

--- a/addons/characters/CfgVehicles.hpp
+++ b/addons/characters/CfgVehicles.hpp
@@ -1,54 +1,69 @@
+#define UNLOCK_MALARIA_CIVILIAN  \
+    editorSubcategory = "EdSubcat_Personnel_Sick"; \
+    scope = 2; \
+    scopeCurator = 2; \
+    class EventHandlers { \
+        init = "(_this select 0) setIdentity selectRandom [ \
+            'BIS_Ambient01_sick', \
+            'BIS_Ambient02_sick', \
+            'BIS_Ambient03_sick', \
+            'BIS_Arthur_Sick', \
+            'BIS_Howard_sick', \
+            'BIS_John_sick', \
+            'BIS_Lucas_sick', \
+            'BIS_Renly_sick' \
+        ]; \
+        (_this select 0) setDamage 0.45"; \
+    }
+
 class CfgVehicles {
-    // External class reference
     class C_Man_casual_1_F_afro;
+    class C_Man_casual_1_F_afro_sick: C_Man_casual_1_F_afro {
+       UNLOCK_MALARIA_CIVILIAN;
+    };
+
     class C_Man_casual_3_F_afro;
+    class C_Man_casual_3_F_afro_sick: C_Man_casual_3_F_afro {
+       UNLOCK_MALARIA_CIVILIAN;
+    };
+
     class C_Man_casual_4_F_afro;
+    class C_Man_casual_4_F_afro_sick: C_Man_casual_4_F_afro {
+       UNLOCK_MALARIA_CIVILIAN;
+    };
+
     class C_Man_casual_5_F_afro;
+    class C_Man_casual_5_F_afro_sick: C_Man_casual_5_F_afro {
+       UNLOCK_MALARIA_CIVILIAN;
+    };
+
     class C_Man_casual_6_F_afro;
+    class C_Man_casual_6_F_afro_sick: C_Man_casual_6_F_afro {
+       UNLOCK_MALARIA_CIVILIAN;
+    };
+
     class C_man_polo_1_F_afro;
+    class C_man_polo_1_F_afro_sick: C_man_polo_1_F_afro {
+       UNLOCK_MALARIA_CIVILIAN;
+    };
+
     class C_man_polo_2_F_afro;
+    class C_man_polo_2_F_afro_sick: C_man_polo_2_F_afro {
+       UNLOCK_MALARIA_CIVILIAN;
+    };
+
     class C_man_polo_3_F_afro;
+    class C_man_polo_3_F_afro_sick: C_man_polo_3_F_afro {
+       UNLOCK_MALARIA_CIVILIAN;
+    };
+
     class C_man_polo_6_F_afro;
+    class C_man_polo_6_F_afro_sick: C_man_polo_6_F_afro {
+       UNLOCK_MALARIA_CIVILIAN;
+    };
+
     class C_man_sport_2_F_afro;
-
-    class C_Man_casual_1_F_afro_sick : C_Man_casual_1_F_afro {
-        C_MAN_SICK_ATTRIBUTE_MODIFICATIONS
-    };
-
-    class C_Man_casual_3_F_afro_sick : C_Man_casual_3_F_afro {
-        C_MAN_SICK_ATTRIBUTE_MODIFICATIONS
-    };
-
-    class C_Man_casual_4_F_afro_sick : C_Man_casual_4_F_afro {
-        C_MAN_SICK_ATTRIBUTE_MODIFICATIONS
-    };
-
-    class C_Man_casual_5_F_afro_sick : C_Man_casual_5_F_afro {
-        C_MAN_SICK_ATTRIBUTE_MODIFICATIONS
-    };
-
-    class C_Man_casual_6_F_afro_sick : C_Man_casual_6_F_afro {
-        C_MAN_SICK_ATTRIBUTE_MODIFICATIONS
-    };
-
-    class C_man_polo_1_F_afro_sick : C_man_polo_1_F_afro {
-        C_MAN_SICK_ATTRIBUTE_MODIFICATIONS
-    };
-
-    class C_man_polo_2_F_afro_sick : C_man_polo_2_F_afro {
-        C_MAN_SICK_ATTRIBUTE_MODIFICATIONS
-    };
-
-    class C_man_polo_3_F_afro_sick : C_man_polo_3_F_afro {
-        C_MAN_SICK_ATTRIBUTE_MODIFICATIONS
-    };
-
-    class C_man_polo_6_F_afro_sick : C_man_polo_6_F_afro {
-        C_MAN_SICK_ATTRIBUTE_MODIFICATIONS
-    };
-
-    class C_man_sport_2_F_afro_sick : C_man_sport_2_F_afro {
-        C_MAN_SICK_ATTRIBUTE_MODIFICATIONS
+    class C_man_sport_2_F_afro_sick: C_man_sport_2_F_afro {
+       UNLOCK_MALARIA_CIVILIAN;
     };
 };
-

--- a/addons/characters/config.cpp
+++ b/addons/characters/config.cpp
@@ -12,7 +12,7 @@ class CfgPatches {
         url = ECSTRING(main,URL);
         VERSION_CONFIG;
 
-        // this prevents any patched class from requiring this addon
+        // This prevents any patched class from requiring this addon
         addonRootClass = "A3_Characters_F";
     };
 };

--- a/addons/characters/config.cpp
+++ b/addons/characters/config.cpp
@@ -1,0 +1,21 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"zen_common","a3_characters_f_oldman"};
+        author = ECSTRING(main,Author);
+        authors[] = {"Kex"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+
+        // this prevents any patched class from requiring this addon
+        addonRootClass = "A3_Characters_F";
+    };
+};
+
+#include "CfgEditorSubcategories.hpp"
+#include "CfgVehicles.hpp"

--- a/addons/characters/config.cpp
+++ b/addons/characters/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"zen_common","a3_characters_f_oldman"};
+        requiredAddons[] = {"zen_common"};
         author = ECSTRING(main,Author);
         authors[] = {"Kex"};
         url = ECSTRING(main,URL);

--- a/addons/characters/script_component.hpp
+++ b/addons/characters/script_component.hpp
@@ -15,3 +15,21 @@
 #endif
 
 #include "\x\zen\addons\main\script_macros.hpp"
+
+#define C_MAN_SICK_ATTRIBUTE_MODIFICATIONS \
+    editorSubcategory = "EdSubcat_Personnel_Sick";\
+    scope = 2;\
+    scopeCurator = 2;\
+    class EventHandlers {\
+        init = "(_this select 0) setIdentity selectRandom [\
+            'BIS_Ambient01_sick',\
+            'BIS_Ambient02_sick',\
+            'BIS_Ambient03_sick',\
+            'BIS_Arthur_Sick',\
+            'BIS_Howard_sick',\
+            'BIS_John_sick',\
+            'BIS_Lucas_sick',\
+            'BIS_Renly_sick'\
+        ];\
+        (_this select 0) setDamage 0.45";\
+    };

--- a/addons/characters/script_component.hpp
+++ b/addons/characters/script_component.hpp
@@ -15,21 +15,3 @@
 #endif
 
 #include "\x\zen\addons\main\script_macros.hpp"
-
-#define C_MAN_SICK_ATTRIBUTE_MODIFICATIONS \
-    editorSubcategory = "EdSubcat_Personnel_Sick";\
-    scope = 2;\
-    scopeCurator = 2;\
-    class EventHandlers {\
-        init = "(_this select 0) setIdentity selectRandom [\
-            'BIS_Ambient01_sick',\
-            'BIS_Ambient02_sick',\
-            'BIS_Ambient03_sick',\
-            'BIS_Arthur_Sick',\
-            'BIS_Howard_sick',\
-            'BIS_John_sick',\
-            'BIS_Lucas_sick',\
-            'BIS_Renly_sick'\
-        ];\
-        (_this select 0) setDamage 0.45";\
-    };

--- a/addons/characters/script_component.hpp
+++ b/addons/characters/script_component.hpp
@@ -1,0 +1,17 @@
+#define COMPONENT characters
+#define COMPONENT_BEAUTIFIED Characters
+#include "\x\zen\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_CHARACTERS
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_CHARACTERS
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_CHARACTERS
+#endif
+
+#include "\x\zen\addons\main\script_macros.hpp"

--- a/addons/characters/stringtable.xml
+++ b/addons/characters/stringtable.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="ZEN">
+    <Package name="Characters">
+        <Key ID="STR_ZEN_Characters_MenSick">
+            <English>Men (Malaria-Infected)</English>
+            <French>Hommes (Infectés par la malaria)</French>
+            <German>Männer (Malariainfiziert)</German>
+        </Key>
+    </Package>
+</Project>


### PR DESCRIPTION
#### Preface:
The Old Man update introduced malaria-infected civilians, however these classes are currently not visible in Eden and Zeus. The way they work is that they change the wound textures of the base civilian classes, which means that the infection is only visible when the unit is injured.

#### When merged this pull request will:
- Unlock malaria-infected civilian classes.
- Set the proper identities for malaria-infected civilian (fixes the faces).
- Add damage to malaria-infected civilian to make the infection visible.