### PR TITLE
Extended Vehicle Customization

### DIFF
--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -1,6 +1,7 @@
 PREP(changeGroupSide);
 PREP(collapseTree);
 PREP(createZeus);
+PREP(customizeVehicle);
 PREP(deployCountermeasures);
 PREP(deserializeInventory);
 PREP(deserializeObjects);
@@ -27,6 +28,7 @@ PREP(getSelectedUnits);
 PREP(getSelectedVehicles);
 PREP(getSideIcon);
 PREP(getVehicleAmmo);
+PREP(getVehicleCustomization);
 PREP(getVehicleIcon);
 PREP(getWeaponReloadTime);
 PREP(hasDefaultInventory);

--- a/addons/common/functions/fnc_customizeVehicle.sqf
+++ b/addons/common/functions/fnc_customizeVehicle.sqf
@@ -1,0 +1,52 @@
+#include "script_component.hpp"
+/*
+ * Author: Kex
+ * Changes the textures, animation sources and/or mass of a given vehicle.
+ * Based on BIS_fnc_initVehicle, but can be applied multiple times without issues.
+ * In contrast to BIS_fnc_initVehicle, if texture is passed as an array,
+ * it expect an array of texture paths (i.e. output of getObjectTextures).
+ *
+ * Arguments:
+ * 0: Vehicle <OBJECT>
+ * 1: Texture <BOOLEAN|ARRAY|STRING>
+ * 2: Animation <BOOLEAN|ARRAY|STRING>
+ * 3: Mass <BOOLEAN|NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [vehicle player, [texturePath1, texturePath2], [animationSource1, animationPhase1]] call zen_common_fnc_customizeVehicle
+ *
+ * Public: No
+ */
+
+params ["_vehicle", ["_texture", false, [false, [], ""]], ["_animation", false, [false, [], ""]], ["_mass", false, [false, 0]]];
+
+// Fix: BIS_fnc_initVehicle cannot animate doors multiple times
+if (_animation isEqualType []) then {
+    for "_i" from (count _animation - 2) to 0 step -2 do {
+        private _name = _animation select _i;
+        private _phase = _animation select (_i + 1);
+        if ("door" in toLower _name) then {
+            _vehicle animateDoor [_name, _phase];
+            // Remove entry, since already handled
+            _animation deleteAt _i;
+            _animation deleteAt _i;
+        };
+    };
+    if (_animation isEqualTo []) then {
+        _animation = nil;
+    };
+};
+
+if (_texture isEqualType []) then {
+    [_vehicle, nil, _animation, _mass] call BIS_fnc_initVehicle;
+    {
+        _vehicle setObjectTextureGlobal [_forEachIndex, _x];
+    } forEach _texture;
+} else {
+    [_vehicle, _texture, _animation, _mass] call BIS_fnc_initVehicle;
+};
+
+nil

--- a/addons/common/functions/fnc_deserializeObjects.sqf
+++ b/addons/common/functions/fnc_deserializeObjects.sqf
@@ -149,7 +149,7 @@ private _fnc_deserializeVehicle = {
         [_vehicle, "", []] call BIS_fnc_initVehicle;
     } else {
         _customization params ["_textures", "_animations"];
-        [_vehicle, _textures, _animations, true] call BIS_fnc_initVehicle;
+        [_vehicle, _textures, _animations, true] call FUNC(customizeVehicle);
     };
 
     {

--- a/addons/common/functions/fnc_exportMissionSQF.sqf
+++ b/addons/common/functions/fnc_exportMissionSQF.sqf
@@ -246,8 +246,9 @@ private _fnc_processVehicle = {
             _outputObjects pushBack ["%1 forceFlagTexture %2;", _varName, str _flagTexture];
         };
 
-        (_vehicle call BIS_fnc_getVehicleCustomization) params ["_textures", "_animations"];
-        _outputObjects pushBack ["[%1, %2, %3, true] call BIS_fnc_initVehicle;", _varName, _textures, _animations];
+        (_vehicle call FUNC(getVehicleCustomization)) params ["_textures", "_animations"];
+        _outputObjects pushBack ["[%1, nil, %2, true] call BIS_fnc_initVehicle;", _varName, _animations];
+        _outputObjects pushBack ["{%1 setObjectTextureGlobal [_forEachIndex, _x]} forEach %2;", _varName, _textures];
 
         [_vehicle, _varName] call _fnc_processInventory;
 

--- a/addons/common/functions/fnc_getVehicleCustomization.sqf
+++ b/addons/common/functions/fnc_getVehicleCustomization.sqf
@@ -1,0 +1,47 @@
+#include "script_component.hpp"
+/*
+ * Author: Kex
+ * Return vehicle customization settings.
+ * Based on BIS_fnc_getVehicleCustomization.
+ * In contrast to BIS_fnc_getVehicleCustomization, it works properly for doors
+ * and textures are returned as an array of texture paths (i.e. output of getObjectTextures).
+ *
+ * Arguments:
+ * 0: Vehicle <OBJECT>
+ *
+ * Return Value:
+ * Array of texture paths and array of animations <ARRAY>
+ *
+ * Example:
+ * [vehicle player] call zen_common_fnc_getVehicleCustomization
+ *
+ * Public: No
+ */
+
+params ["_vehicle"];
+
+private _vehicleType = typeOf _vehicle;
+private _vehicleConfig = configFile >> "CfgVehicles" >> _vehicleType;
+
+private _animations = [];
+{
+    private _config = _x;
+    private _configName = configName _config;
+    private _source = getText (_config >> "source");
+
+    if (!(toLower _configName in BLACKLIST_ANIMATION_NAMES) && {!(toLower _source in BLACKLIST_ANIMATION_SOURCES) && {BLACKLIST_ANIMATION_ATTRIBUTES findIf {isClass (_config >> _x)} == -1}}) then {
+        private _phase = if ("door" in toLower _configName) then {
+            _vehicle doorPhase _configName;
+        } else {
+            _vehicle animationPhase _configName;
+        };
+        // Some sources will return negative values
+        if (_phase >= 0) then {
+            _animations append [_configName, _phase];
+        }
+    };
+} forEach configProperties [_vehicleConfig >> "animationSources", "isClass _x", true];
+
+private _textures = getObjectTextures _vehicle;
+
+[_textures, _animations]

--- a/addons/common/functions/fnc_serializeObjects.sqf
+++ b/addons/common/functions/fnc_serializeObjects.sqf
@@ -118,7 +118,7 @@ private _fnc_serializeVehicle = {
 
     private _fuel = fuel _vehicle;
     private _inventory = _vehicle call FUNC(serializeInventory);
-    private _customization = _vehicle call BIS_fnc_getVehicleCustomization;
+    private _customization = _vehicle call FUNC(getVehicleCustomization);
     private _flagTexture = getForcedFlagTexture _vehicle;
 
     private _pylonMagazines = getPylonMagazines _vehicle;

--- a/addons/common/script_component.hpp
+++ b/addons/common/script_component.hpp
@@ -68,3 +68,8 @@
 
 // Prevent certain magazines from being handled by ammo functions
 #define BLACKLIST_MAGAZINES ["Laserbatteries"]
+
+// Prevent certain source animations from being displayed in the garage
+#define BLACKLIST_ANIMATION_SOURCES ["hit", "markerlight"]
+#define BLACKLIST_ANIMATION_NAMES ["proxy", "doors"]
+#define BLACKLIST_ANIMATION_ATTRIBUTES ["weapon", "wheel"]

--- a/addons/garage/XEH_PREP.hpp
+++ b/addons/garage/XEH_PREP.hpp
@@ -1,5 +1,6 @@
 PREP(applyToAll);
 PREP(closeGarage);
+PREP(defineCustomTexture);
 PREP(getVehicleData);
 PREP(handleMouse);
 PREP(onAnimationSelect);

--- a/addons/garage/XEH_preInit.sqf
+++ b/addons/garage/XEH_preInit.sqf
@@ -20,4 +20,6 @@ GVAR(camYaw) = -45;
     true
 ] call EFUNC(attributes,addButton);
 
+#include "initCustomVehicleTextures.sqf"
+
 ADDON = true;

--- a/addons/garage/functions/fnc_applyToAll.sqf
+++ b/addons/garage/functions/fnc_applyToAll.sqf
@@ -16,12 +16,12 @@
  * Public: No
  */
 
-(GVAR(center) call BIS_fnc_getVehicleCustomization) params ["_texture", "_animations"];
+(GVAR(center) call EFUNC(common,getVehicleCustomization)) params ["_textures", "_animations"];
 
 private _vehicleType = typeOf GVAR(center);
 
 {
     if (typeOf _x isEqualTo _vehicleType) then {
-        [_x, _texture, _animations, true] call BIS_fnc_initVehicle;
+        [_x, _textures, _animations, true] call EFUNC(common,customizeVehicle);
     };
 } forEach SELECTED_OBJECTS;

--- a/addons/garage/functions/fnc_defineCustomTexture.sqf
+++ b/addons/garage/functions/fnc_defineCustomTexture.sqf
@@ -1,0 +1,36 @@
+#include "script_component.hpp"
+/*
+ * Author: Kex
+ * Defines custom texture variant for all vehicles that inherit from the given vehicle type.
+ *
+ * Arguments:
+ * 0: Base vehicle type <STRING>
+ * 1: Texture variant name <STRING>
+ * 2: Path of texture for each hidden selection <ARRAY>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [vehicleType, variantName, [texturePath1, texturePath2]] call zen_garage_fnc_defineCustomTexture
+ *
+ * Public: Yes
+ */
+
+params ["_baseVehicleType", "_variantName", "_texture"];
+
+if (isNil QGVAR(customVehicleTextures)) then {
+    GVAR(customVehicleTextures) = [] call CBA_fnc_createNamespace;
+};
+
+{
+    private _vehicleType = configName _x;
+    // Clear garage cache
+    GVAR(vehicleDataCache) setVariable [_vehicleType, []];
+
+    private _textures = GVAR(customVehicleTextures) getVariable [_vehicleType, []];
+    _textures pushBack [_texture, _variantName];
+    GVAR(customVehicleTextures) setVariable [_vehicleType, _textures];
+} forEach (format ["configName _x isKindOf '%1'", _baseVehicleType] configClasses (configFile / "CfgVehicles"));
+
+nil

--- a/addons/garage/functions/fnc_onAnimationSelect.sqf
+++ b/addons/garage/functions/fnc_onAnimationSelect.sqf
@@ -31,4 +31,4 @@ for "_i" from 0 to (lbSize _ctrlListAnimations - 1) do {
 };
 
 // Update vehicle animations
-[GVAR(center), nil, _animations, true] call BIS_fnc_initVehicle;
+[GVAR(center), nil, _animations, true] call EFUNC(common,customizeVehicle);

--- a/addons/garage/functions/fnc_onTextureSelect.sqf
+++ b/addons/garage/functions/fnc_onTextureSelect.sqf
@@ -26,5 +26,12 @@ for "_i" from 0 to (lbSize _ctrlListTextures - 1) do {
 // Check selected texture
 _ctrlListTextures lbSetPicture [_selectedIndex, ICON_CHECKED];
 
+private _texture = _ctrlListTextures lbData _selectedIndex;
+
+// Handle serialized array
+if (_texture != "" && {_texture select [0, 1] == '['}) then {
+    _texture = parseSimpleArray _texture;
+};
+
 // Update vehicle textures
-[GVAR(center), [_ctrlListTextures lbData _selectedIndex, 1]] call BIS_fnc_initVehicle;
+[GVAR(center), _texture] call EFUNC(common,customizeVehicle);

--- a/addons/garage/initCustomVehicleTextures.sqf
+++ b/addons/garage/initCustomVehicleTextures.sqf
@@ -1,0 +1,102 @@
+// Add hidden Tempest variants
+[
+   "O_Truck_03_ammo_F",
+    format ["%1 (%2)", localize "STR_A3_texturesources_hex0", localize "str_a3_rscdisplayaanarticle_menu_3"],
+    [
+        "\A3\Soft_F_EPC\Truck_03\Data\Truck_03_ext01_CO.paa",
+        "\A3\Soft_F_EPC\Truck_03\Data\Truck_03_ext02_CO.paa",
+        "\A3\Soft_F_EPC\Truck_03\Data\Truck_03_cargo_CO.paa",
+        "\A3\missions_f_oldman\Data\img\Decals\science_containers_tempest_co.paa"
+    ]
+] call FUNC(defineCustomTexture);
+[
+    "O_Truck_03_ammo_F",
+    format ["%1 (%2)", localize "STR_A3_texturesources_greenhex0", localize "str_a3_rscdisplayaanarticle_menu_3"],
+    [
+        "\A3\Soft_F_Exp\Truck_03\Data\Truck_03_ext01_ghex_CO.paa",
+        "\A3\Soft_F_Exp\Truck_03\Data\Truck_03_ext02_ghex_CO.paa",
+        "\A3\Soft_F_Exp\Truck_03\Data\Truck_03_cargo_ghex_CO.paa",
+        "\A3\missions_f_oldman\Data\img\Decals\science_containers_tempest_co.paa"
+    ]
+] call FUNC(defineCustomTexture);
+
+// Add hidden Taru variants
+{
+    [
+       _x,
+        format ["%1 (%2)", localize "str_a3_texturesources_black0", localize "str_a3_rscdisplayaanarticle_menu_3"],
+        [
+            "A3\Air_F_Heli\Heli_Transport_04\Data\heli_transport_04_base_01_Black_co.paa",
+            "A3\Air_F_Heli\Heli_Transport_04\Data\heli_transport_04_base_02_Black_co.paa",
+            "A3\missions_f_oldman\Data\img\Decals\science_pods_co.paa",
+            "A3\Air_F_Heli\Heli_Transport_04\Data\Heli_Transport_04_Pod_Ext02_Black_CO.paa"
+        ]
+    ] call FUNC(defineCustomTexture);
+} forEach ["O_Heli_Transport_04_covered_F", "O_Heli_Transport_04_medevac_F", "O_Heli_Transport_04_box_F"];
+
+// Add hidden Gorgon variants
+[
+    "I_APC_Wheeled_03_cannon_F",
+    localize "str_a3_texturesources_sand0",
+    [
+        "A3\Armor_F_Gamma\APC_Wheeled_03\Data\apc_wheeled_03_ext_co.paa",
+        "A3\Armor_F_Gamma\APC_Wheeled_03\Data\apc_wheeled_03_ext2_co.paa",
+        "A3\Armor_F_Gamma\APC_Wheeled_03\Data\rcws30_co.paa",
+        "A3\Armor_F_Gamma\APC_Wheeled_03\Data\apc_wheeled_03_ext_alpha_co.paa"
+    ]
+] call FUNC(defineCustomTexture);
+
+// Add hidden Blackfoot variants
+[
+    "B_Heli_Attack_01_dynamicLoadout_F",
+    localize "STR_A3_TEXTURESOURCES_OLIVE0",
+    [
+        "\A3\Air_F_Beta\heli_attack_01\data\heli_attack_01_co.paa"
+    ]
+] call FUNC(defineCustomTexture);
+[
+    "B_Heli_Attack_01_dynamicLoadout_F",
+    localize "str_a3_texturesources_green0",
+    [
+        "A3\Air_F\Heli_Light_02\Data\heli_light_02_common_co.paa"
+    ]
+] call FUNC(defineCustomTexture);
+[
+    "B_Heli_Attack_01_dynamicLoadout_F",
+    localize "str_a3_texturesources_black0",
+    [
+        "A3\Air_F_Beta\heli_attack_01\data\UI\Heli_Attack_01_EDEN_CA.PAA"
+    ]
+] call FUNC(defineCustomTexture);
+
+// Add hidden Orca variants
+[
+    "Heli_Light_02_base_F",
+    localize "str_a3_cfgfactionclasses_ind_f0",
+    [
+        "\a3\air_f\Heli_Light_02\Data\heli_light_02_ext_indp_co.paa"
+    ]
+] call FUNC(defineCustomTexture);
+
+// Add hidden Pawnee/Hummingbird variants
+[
+    "Heli_Light_01_base_F",
+    localize "str_a3_texturesources_green0",
+    [
+        "A3\Air_F\Heli_Light_01\Data\Heli_Light_01_ext_Blufor_CO.paa"
+    ]
+] call FUNC(defineCustomTexture);
+[
+    "Heli_Light_01_base_F",
+    localize "str_a3_texturesources_black0",
+    [
+        "\a3\air_f\Heli_Light_01\Data\heli_light_01_ext_ion_co.paa"
+    ]
+] call FUNC(defineCustomTexture);
+[
+    "Heli_Light_01_base_F",
+    localize "str_a3_cfgfactionclasses_ind_f0",
+    [
+        "A3\Air_F\Heli_Light_01\Data\heli_light_01_ext_indp_co.paa"
+    ]
+] call FUNC(defineCustomTexture);


### PR DESCRIPTION
**When merged this pull request will:**
- Provide `zen_garage_fnc_defineCustomTexture` as API function for defining custom textures for the garage.
- Unlock hidden vanilla textures for the garage.
- Unlock additional animation sources for the garage (_e.g._ vehicle doors).
- Add support for the extended customization to deep copy/paste and SQF exporter.