### PR TITLE
Fix intel module, Copy dialog values when saving

### DIFF
--- a/addons/dialog/functions/fnc_close.sqf
+++ b/addons/dialog/functions/fnc_close.sqf
@@ -30,7 +30,8 @@ private _values = _controls apply {
 // Call the appropriate confirm/cancel function
 if (_confirmed) then {
     // Save values when the selections are confirmed
-    GVAR(saved) setVariable [_saveID, _values];
+    // Make a copy to prevent issues from the values array being modified by reference
+    GVAR(saved) setVariable [_saveID, +_values];
 
     [_values, _args] call _onConfirm;
 } else {


### PR DESCRIPTION
**When merged this pull request will:**
- Fix intel module causing an error on second usage after dialog rework
- After rework, the values array was the same one that was saved
- Saving a copy will prevent any issues from the values array being modified by reference (as done by the intel module)
