### PR TITLE
Preload Addons

### DIFF
--- a/addons/ai/config.cpp
+++ b/addons/ai/config.cpp
@@ -14,4 +14,6 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"

--- a/addons/area_markers/config.cpp
+++ b/addons/area_markers/config.cpp
@@ -16,6 +16,8 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"
 #include "CfgVehicles.hpp"
 #include "CfgContext.hpp"

--- a/addons/attributes/config.cpp
+++ b/addons/attributes/config.cpp
@@ -14,6 +14,8 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"
 #include "CfgFunctions.hpp"
 #include "CfgVehicles.hpp"

--- a/addons/camera/config.cpp
+++ b/addons/camera/config.cpp
@@ -14,4 +14,6 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"

--- a/addons/common/config.cpp
+++ b/addons/common/config.cpp
@@ -14,5 +14,7 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"
 #include "gui.hpp"

--- a/addons/compositions/config.cpp
+++ b/addons/compositions/config.cpp
@@ -16,6 +16,8 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"
 #include "CfgVehicleIcons.hpp"
 #include "CfgVehicles.hpp"

--- a/addons/context_actions/config.cpp
+++ b/addons/context_actions/config.cpp
@@ -19,5 +19,7 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"
 #include "CfgContext.hpp"

--- a/addons/context_menu/config.cpp
+++ b/addons/context_menu/config.cpp
@@ -14,5 +14,7 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"
 #include "gui.hpp"

--- a/addons/custom_modules/config.cpp
+++ b/addons/custom_modules/config.cpp
@@ -117,5 +117,7 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"
 #include "CfgVehicles.hpp"

--- a/addons/damage/config.cpp
+++ b/addons/damage/config.cpp
@@ -14,4 +14,6 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"

--- a/addons/dialog/config.cpp
+++ b/addons/dialog/config.cpp
@@ -14,5 +14,7 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"
 #include "gui.hpp"

--- a/addons/doors/config.cpp
+++ b/addons/doors/config.cpp
@@ -16,6 +16,8 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"
 #include "CfgVehicles.hpp"
 

--- a/addons/editor/config.cpp
+++ b/addons/editor/config.cpp
@@ -14,6 +14,8 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"
 #include "CfgFunctions.hpp"
 #include "CfgCurator.hpp"

--- a/addons/editor_previews/config.cpp
+++ b/addons/editor_previews/config.cpp
@@ -14,5 +14,7 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"
 #include "gui.hpp"

--- a/addons/flashlight/config.cpp
+++ b/addons/flashlight/config.cpp
@@ -14,4 +14,6 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"

--- a/addons/garage/config.cpp
+++ b/addons/garage/config.cpp
@@ -14,5 +14,7 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"
 #include "gui.hpp"

--- a/addons/inventory/config.cpp
+++ b/addons/inventory/config.cpp
@@ -14,5 +14,7 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"
 #include "gui.hpp"

--- a/addons/loadout/config.cpp
+++ b/addons/loadout/config.cpp
@@ -14,5 +14,7 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"
 #include "gui.hpp"

--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -14,4 +14,6 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgSettings.hpp"

--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -1,4 +1,14 @@
 #define DEBUG_SYNCHRONOUS
+
+#define PRELOAD_ADDONS \
+    class CfgAddons { \
+        class PreloadAddons { \
+            class PREFIX { \
+                list[] += {QUOTE(ADDON)}; \
+            }; \
+        }; \
+    }
+
 #include "\x\cba\addons\main\script_macros_common.hpp"
 #include "\x\cba\addons\xeh\script_xeh.hpp"
 

--- a/addons/markers_tree/config.cpp
+++ b/addons/markers_tree/config.cpp
@@ -14,5 +14,7 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"
 #include "RscDisplayCurator.hpp"

--- a/addons/modules/config.cpp
+++ b/addons/modules/config.cpp
@@ -79,6 +79,8 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"
 #include "CfgFactionClasses.hpp"
 #include "CfgVehicles.hpp"

--- a/addons/music/config.cpp
+++ b/addons/music/config.cpp
@@ -14,4 +14,6 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgMusic.hpp"

--- a/addons/placement/config.cpp
+++ b/addons/placement/config.cpp
@@ -14,4 +14,6 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"

--- a/addons/position_logics/config.cpp
+++ b/addons/position_logics/config.cpp
@@ -14,4 +14,6 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"

--- a/addons/pylons/config.cpp
+++ b/addons/pylons/config.cpp
@@ -14,5 +14,7 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"
 #include "gui.hpp"

--- a/addons/remote_control/config.cpp
+++ b/addons/remote_control/config.cpp
@@ -16,5 +16,7 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"
 #include "CfgVehicles.hpp"

--- a/addons/visibility/config.cpp
+++ b/addons/visibility/config.cpp
@@ -14,4 +14,6 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"

--- a/addons/vision/config.cpp
+++ b/addons/vision/config.cpp
@@ -14,6 +14,8 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"
 #include "CfgFunctions.hpp"
 #include "RscTitles.hpp"

--- a/extras/blank/config.cpp
+++ b/extras/blank/config.cpp
@@ -14,4 +14,6 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"

--- a/optionals/compat_ace/config.cpp
+++ b/optionals/compat_ace/config.cpp
@@ -14,6 +14,8 @@ class CfgPatches {
     };
 };
 
+PRELOAD_ADDONS;
+
 #include "CfgEventHandlers.hpp"
 #include "CfgVehicles.hpp"
 #include "ACE_ZeusActions.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Add `CfgAddons` entries for all components
- Adds ZEN addons to curators even if "All addons (including unofficial ones)" isn't selected in Game Master module
- Should help with `curatorAddons` being lost after game save/load