### PR TITLE
Add display to configure pylon loadouts

### DIFF
--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -31,6 +31,7 @@ PREP(getVehicleAmmo);
 PREP(getVehicleIcon);
 PREP(getWeaponReloadTime);
 PREP(hasDefaultInventory);
+PREP(hasPylons);
 PREP(healUnit);
 PREP(initDisplayPositioning);
 PREP(initOwnersControl);

--- a/addons/common/functions/fnc_hasPylons.sqf
+++ b/addons/common/functions/fnc_hasPylons.sqf
@@ -1,0 +1,24 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Checks if the given vehicle has configurable pylons.
+ *
+ * Arguments:
+ * 0: Vehicle <OBJECT|STRING>
+ *
+ * Return Value:
+ * Has Pylons <BOOL>
+ *
+ * Example:
+ * [_vehicle] call zen_common_fnc_hasPylons
+ *
+ * Public: No
+ */
+
+params ["_vehicle"];
+
+if (_vehicle isEqualType objNull) then {
+    _vehicle = typeOf _vehicle;
+};
+
+isClass (configFile >> "CfgVehicles" >> _vehicle >> "Components" >> "TransportPylonsComponent")

--- a/addons/pylons/$PBOPREFIX$
+++ b/addons/pylons/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\zen\addons\pylons

--- a/addons/pylons/CfgEventHandlers.hpp
+++ b/addons/pylons/CfgEventHandlers.hpp
@@ -1,0 +1,17 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+    };
+};
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
+    };
+};

--- a/addons/pylons/XEH_PREP.hpp
+++ b/addons/pylons/XEH_PREP.hpp
@@ -1,0 +1,6 @@
+PREP(configure);
+PREP(handleConfirm);
+PREP(handleMagazineSelect);
+PREP(handleMirror);
+PREP(handlePreset);
+PREP(handleTurretButton);

--- a/addons/pylons/XEH_postInit.sqf
+++ b/addons/pylons/XEH_postInit.sqf
@@ -1,0 +1,19 @@
+#include "script_component.hpp"
+
+[QGVAR(setLoadout), {
+    params ["_aircraft", "_pylonLoadout"];
+
+    {
+        _x params ["_magazine", "_turretPath"];
+
+        _aircraft setPylonLoadout [_forEachIndex + 1, _magazine, false, _turretPath];
+    } forEach _pylonLoadout;
+}] call CBA_fnc_addEventHandler;
+
+[QGVAR(removeWeapons), {
+    params ["_aircraft", "_turretPath", "_weapons"];
+
+    {
+        _aircraft removeWeaponTurret [_x, _turretPath];
+    } forEach _weapons;
+}] call CBA_fnc_addEventHandler;

--- a/addons/pylons/XEH_preInit.sqf
+++ b/addons/pylons/XEH_preInit.sqf
@@ -1,0 +1,21 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+PREP_RECOMPILE_START;
+#include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
+
+// Add pylons button to attribute display
+[
+    "Object",
+    LSTRING(DisplayName),
+    {
+        _entity call FUNC(configure);
+    },
+    {
+        alive _entity && {_entity call EFUNC(common,hasPylons)}
+    }
+] call EFUNC(attributes,addButton);
+
+ADDON = true;

--- a/addons/pylons/XEH_preStart.sqf
+++ b/addons/pylons/XEH_preStart.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+#include "XEH_PREP.hpp"

--- a/addons/pylons/config.cpp
+++ b/addons/pylons/config.cpp
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"zen_attributes"};
+        author = ECSTRING(main,Author);
+        authors[] = {"mharis001"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgEventHandlers.hpp"
+#include "gui.hpp"

--- a/addons/pylons/functions/fnc_configure.sqf
+++ b/addons/pylons/functions/fnc_configure.sqf
@@ -1,0 +1,137 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Opens a dialog to configure the pylons of the given aircraft.
+ *
+ * Arguments:
+ * 0: Aircraft <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [_aircraft] call zen_pylons_fnc_configure
+ *
+ * Public: No
+ */
+
+params ["_aircraft"];
+
+if (!createDialog QGVAR(display)) exitWith {};
+
+private _display = uiNamespace getVariable QGVAR(display);
+
+private _config = configFile >> "CfgVehicles" >> typeOf _aircraft;
+private _pylonsConfig = _config >> "Components" >> "TransportPylonsComponent";
+
+// Set the display's title to the aircraft name
+private _ctrlTitle = _display displayCtrl IDC_TITLE;
+_ctrlTitle ctrlSetText toUpper format [localize LSTRING(Title), getText (_config >> "displayName")];
+
+// Set the aircraft's pylons UI picture
+private _ctrlPicture = _display displayCtrl IDC_PICTURE;
+_ctrlPicture ctrlSetText getText (_pylonsConfig >> "uiPicture");
+
+ctrlPosition _ctrlPicture params ["_pictureX", "_pictureY", "_pictureW", "_pictureH"];
+
+private _cfgMagazines = configFile >> "CfgMagazines";
+private _currentMagazines = getPylonMagazines _aircraft;
+private _hasGunner = [0] in allTurrets [_aircraft, false];
+
+// Create controls to configure the aircraft's pylons
+private _controls = [];
+
+{
+    private _uiPos = getArray (_x >> "UIposition") apply {
+        if (_x isEqualType "") then {call compile _x} else {_x}
+    };
+
+    _uiPos params ["_uiPosX", "_uiPosY"];
+
+    private _posX = _pictureX + _uiPosX * _pictureW * SCALE_FACTOR_X;
+    private _posY = _pictureY + _uiPosY * _pictureH * SCALE_FACTOR_Y;
+
+    private _mirroredIndex = getNumber (_x >> "mirroredMissilePos") - 1;
+    private _defaultTurretPath = getArray (_x >> "turret");
+
+    private _ctrlCombo = _display ctrlCreate ["ctrlCombo", -1];
+    _ctrlCombo ctrlSetPosition [_posX, _posY, GRID_W(82/3), GRID_H(5)];
+    _ctrlCombo ctrlCommit 0;
+
+    _ctrlCombo ctrlAddEventHandler ["LBSelChanged", {call FUNC(handleMagazineSelect)}];
+    _ctrlCombo setVariable [QGVAR(index), _forEachIndex];
+
+    _ctrlCombo lbAdd localize LSTRING(Empty);
+    _ctrlCombo lbSetCurSel 0;
+
+    // Add compatible magazines to the combo box
+    private _currentMagazine = _currentMagazines select _forEachIndex;
+
+    {
+        private _config = _cfgMagazines >> _x;
+        private _name = getText (_config >> "displayName");
+        private _tooltip = getText (_config >> "descriptionShort");
+
+        private _index = _ctrlCombo lbAdd _name;
+        _ctrlCombo lbSetTooltip [_index, _tooltip];
+        _ctrlCombo lbSetData [_index, _x];
+
+        if (_x == _currentMagazine) then {
+            _ctrlCombo lbSetCurSel _index;
+        };
+    } forEach (_aircraft getCompatiblePylonMagazines configName _x);
+
+    // Create turret button if aircraft has a gunner position
+    private _ctrlTurret = controlNull;
+
+    if (_hasGunner) then {
+        _ctrlTurret = _display ctrlCreate ["ctrlButtonPictureKeepAspect", -1];
+        _ctrlTurret ctrlSetPosition [_posX - GRID_W(5), _posY, GRID_W(5), GRID_H(5)];
+        _ctrlTurret ctrlCommit 0;
+
+        private _turretPath = [_aircraft, _forEachIndex] call EFUNC(common,getPylonTurret);
+        _ctrlTurret setVariable [QGVAR(turretPath), _turretPath];
+        _ctrlTurret setVariable [QGVAR(index), _forEachIndex];
+        _ctrlTurret call FUNC(handleTurretButton);
+
+        // Toggle the pylon's turret when the button is clicked
+        _ctrlTurret ctrlAddEventHandler ["ButtonClick", {
+            params ["_ctrlTurret"];
+
+            [_ctrlTurret, true] call FUNC(handleTurretButton);
+        }];
+    };
+
+    _controls pushBack [_ctrlCombo, _ctrlTurret, _mirroredIndex, _defaultTurretPath];
+} forEach configProperties [_pylonsConfig >> "Pylons", "isClass _x"];
+
+_display setVariable [QGVAR(aircraft), _aircraft];
+_display setVariable [QGVAR(controls), _controls];
+
+// Add the aircraft's pylons presets to the presets combo box
+private _ctrlPresets = _display displayCtrl IDC_PRESETS;
+_ctrlPresets lbAdd localize "STR_Radio_Custom";
+_ctrlPresets lbSetPicture [0, ICON_JETS];
+_ctrlPresets lbSetCurSel 0;
+
+{
+    private _index = _ctrlPresets lbAdd getText (_x >> "displayName");
+    _ctrlPresets lbSetPicture [_index, ICON_JETS];
+    _ctrlPresets setVariable [str _index, getArray (_x >> "attachment")];
+} forEach configProperties [_pylonsConfig >> "Presets", "isClass _x"];
+
+// Update pylons when a preset is selected
+_ctrlPresets ctrlAddEventHandler ["LBSelChanged", {call FUNC(handlePreset)}];
+
+// Toggle pylons mirroring when the checkbox is clicked
+private _ctrlMirror = _display displayCtrl IDC_MIRROR;
+_ctrlMirror ctrlAddEventHandler ["CheckedChanged", {
+    params ["_ctrlMirror", "_checked"];
+
+    private _display = ctrlParent _ctrlMirror;
+    [_display, _checked == 1] call FUNC(handleMirror);
+}];
+
+// Confirm changes to the pylon loadout when the OK button is clicked
+private _ctrlButtonOK = _display displayCtrl IDC_OK;
+_ctrlButtonOK ctrlAddEventHandler ["ButtonClick", {call FUNC(handleConfirm)}];

--- a/addons/pylons/functions/fnc_handleConfirm.sqf
+++ b/addons/pylons/functions/fnc_handleConfirm.sqf
@@ -1,0 +1,82 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles confirming the specified pylon loadout.
+ *
+ * Arguments:
+ * 0: Button <CONTROL>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [CONTROL] call zen_pylons_fnc_handleConfirm
+ *
+ * Public: No
+ */
+
+params ["_ctrlButtonOK"];
+
+private _display = ctrlParent _ctrlButtonOK;
+private _aircraft = _display getVariable QGVAR(aircraft);
+
+private _cfgWeapons = configFile >> "CfgWeapons";
+private _cfgMagazines = configFile >> "CfgMagazines";
+
+// Keep track of default pylon weapons to keep for each turret
+private _driverWeapons = [];
+private _gunnerWeapons = [];
+
+// Get pylon loadout from combo boxes and turret buttons
+private _pylonLoadout = [];
+
+{
+    _x params ["_ctrlCombo", "_ctrlTurret"];
+
+    private _magazine = _ctrlCombo lbData lbCurSel _ctrlCombo;
+    private _turretPath = _ctrlTurret getVariable [QGVAR(turretPath), []];
+
+    private _pylonWeapon = configName (_cfgWeapons >> getText (_cfgMagazines >> _magazine >> "pylonWeapon"));
+
+    if (_turretPath isEqualTo []) then {
+        _driverWeapons pushBackUnique _pylonWeapon;
+    } else {
+        _gunnerWeapons pushBackUnique _pylonWeapon;
+    };
+
+    _pylonLoadout pushBack [_magazine, _turretPath];
+} forEach (_display getVariable QGVAR(controls));
+
+[QGVAR(setLoadout), [_aircraft, _pylonLoadout], _aircraft] call CBA_fnc_targetEvent;
+
+// Get all compatible default pylon weapons for the aircraft
+// These are added automatically if a compatible weapon for the magazine
+// does not exist when using the setPylonLoadout command
+private _pylonWeapons = [];
+
+{
+    _pylonWeapons append (_x apply {
+        configName (_cfgWeapons >> getText (_cfgMagazines >> _x >> "pylonWeapon"))
+    });
+} forEach (_aircraft getCompatiblePylonMagazines 0);
+
+_pylonWeapons = _pylonWeapons arrayIntersect _pylonWeapons;
+
+// Remove default pylons weapons that will no longer be used
+// Prevents weapons with no magazines from showing up when cycling through weapons
+// This will also handle rare situations where a compatible weapon that is not a
+// default pylon weapon was already present on the turret
+{
+    _x params ["_weaponsToKeep", "_turretPath"];
+
+    private _weaponsToRemove = _aircraft weaponsTurret _turretPath select {
+        !(_x in _weaponsToKeep) && {_x in _pylonWeapons}
+    };
+
+    if !(_weaponsToRemove isEqualTo []) then {
+        [QGVAR(removeWeapons), [_aircraft, _turretPath, _weaponsToRemove], _aircraft, _turretPath] call CBA_fnc_turretEvent;
+    };
+} forEach [
+    [_driverWeapons, [-1]],
+    [_gunnerWeapons, [0]]
+];

--- a/addons/pylons/functions/fnc_handleMagazineSelect.sqf
+++ b/addons/pylons/functions/fnc_handleMagazineSelect.sqf
@@ -1,0 +1,47 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles selecting a magazine in the pylon combo boxes.
+ *
+ * Arguments:
+ * 0: Pylon Combo <CONTROL>
+ * 1: Selected Index <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [CONTROL, 0] call zen_pylons_fnc_handleMagazineSelect
+ *
+ * Public: No
+ */
+
+params ["_ctrlCombo", "_selectedIndex"];
+
+private _previousIndex = _ctrlCombo getVariable [QGVAR(previousIndex), 0];
+_ctrlCombo setVariable [QGVAR(previousIndex), _selectedIndex];
+
+// Exit if event handler was triggered by lbSetCurSel command
+// Prevents issues with manually setting selection when loading a preset
+EXIT_LOCKED;
+
+private _display = ctrlParent _ctrlCombo;
+
+// Mimic 3DEN pylons UI behaviour of selecting the custom preset if a different magazine is selected
+if (_selectedIndex != _previousIndex) then {
+    private _ctrlPresets = _display displayCtrl IDC_PRESETS;
+    _ctrlPresets lbSetCurSel 0;
+};
+
+// Handle selecting the same magazine on the mirrored combo box
+if (cbChecked (_display displayCtrl IDC_MIRROR)) then {
+    private _pylonIndex = _ctrlCombo getVariable QGVAR(index);
+
+    {
+        _x params ["_ctrlComboMirrored", "", "_mirroredIndex"];
+
+        if (_mirroredIndex == _pylonIndex) then {
+            _ctrlComboMirrored lbSetCurSel _selectedIndex;
+        };
+    } forEach (_display getVariable QGVAR(controls));
+};

--- a/addons/pylons/functions/fnc_handleMirror.sqf
+++ b/addons/pylons/functions/fnc_handleMirror.sqf
@@ -1,0 +1,48 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles toggling the mirror state of the pylons.
+ *
+ * Arguments:
+ * 0: Display <DISPLAY>
+ * 1: Mirrored <BOOL>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [DISPLAY, true] call zen_pylons_fnc_handleMirror
+ *
+ * Public: No
+ */
+
+params ["_display", "_mirrored"];
+
+private _controls = _display getVariable QGVAR(controls);
+
+if (_mirrored) then {
+    // Mirror current configuration and disable mirrored combo boxes and turret buttons
+    {
+        _x params ["_ctrlCombo", "_ctrlTurret", "_mirroredIndex"];
+
+        if (_mirroredIndex != -1) then {
+            (_controls select _mirroredIndex) params ["_ctrlComboMirrored", "_ctrlTurretMirrored"];
+
+            _ctrlCombo lbSetCurSel lbCurSel _ctrlComboMirrored;
+            _ctrlCombo ctrlEnable false;
+
+            private _turretPath = _ctrlTurretMirrored getVariable QGVAR(turretPath);
+            _ctrlTurret setVariable [QGVAR(turretPath), _turretPath];
+            _ctrlTurret call FUNC(handleTurretButton);
+            _ctrlTurret ctrlEnable false;
+        };
+    } forEach _controls;
+} else {
+    // Enable all combo boxes and turret buttons if pylons are not mirrored
+    {
+        _x params ["_ctrlCombo", "_ctrlTurret"];
+
+        _ctrlCombo ctrlEnable true;
+        _ctrlTurret ctrlEnable true;
+    } forEach _controls;
+};

--- a/addons/pylons/functions/fnc_handlePreset.sqf
+++ b/addons/pylons/functions/fnc_handlePreset.sqf
@@ -1,0 +1,49 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles selecting a pylons preset in the presets combo box.
+ *
+ * Arguments:
+ * 0: Presets Combo <CONTROL>
+ * 1: Selected Index <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [CONTROL, 0] call zen_pylons_fnc_handlePreset
+ *
+ * Public: No
+ */
+
+params ["_ctrlPresets", "_selectedIndex"];
+
+// Exit on custom pylon configuration
+if (_selectedIndex == 0) exitWith {};
+
+// Disable mirroring when selecting a preset
+private _display = ctrlParent _ctrlPresets;
+[_display, false] call FUNC(handleMirror);
+
+private _ctrlMirror = _display displayCtrl IDC_MIRROR;
+_ctrlMirror cbSetChecked false;
+
+// Select the preset's magazines and default pylon turrets
+private _presetMagazines = _ctrlPresets getVariable str _selectedIndex;
+
+{
+    _x params ["_ctrlCombo", "_ctrlTurret", "", "_turretPath"];
+
+    private _magazine = _presetMagazines param [_forEachIndex, ""];
+
+    for "_index" from 0 to (lbSize _ctrlCombo - 1) do {
+        if (_ctrlCombo lbData _index == _magazine) exitWith {
+            LOCK;
+            _ctrlCombo lbSetCurSel _index;
+            UNLOCK;
+        };
+    };
+
+    _ctrlTurret setVariable [QGVAR(turretPath), _turretPath];
+    _ctrlTurret call FUNC(handleTurretButton);
+} forEach (_display getVariable QGVAR(controls));

--- a/addons/pylons/functions/fnc_handleTurretButton.sqf
+++ b/addons/pylons/functions/fnc_handleTurretButton.sqf
@@ -1,0 +1,52 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles setting/toggling the state of pylon turret buttons.
+ *
+ * Arguments:
+ * 0: Turret Button <CONTROL>
+ * 1: Toggle <BOOL> (default: false)
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [CONTROL, true] call zen_pylons_fnc_handleTurretButton
+ *
+ * Public: No
+ */
+
+params ["_ctrlTurret", ["_toggle", false]];
+
+private _turretPath = _ctrlTurret getVariable QGVAR(turretPath);
+
+// Toggle between driver and gunner turret if required
+if (_toggle) then {
+    _turretPath = [[], [0]] select (_turretPath isEqualTo []);
+    _ctrlTurret setVariable [QGVAR(turretPath), _turretPath];
+
+    private _display = ctrlParent _ctrlTurret;
+
+    // Handle toggling the state of the mirrored pylon's button
+    if (cbChecked (_display displayCtrl IDC_MIRROR)) then {
+        private _pylonIndex = _ctrlTurret getVariable QGVAR(index);
+
+        {
+            _x params ["", "_ctrlTurretMirrored", "_mirroredIndex"];
+
+            if (_mirroredIndex == _pylonIndex) exitWith {
+                _ctrlTurretMirrored setVariable [QGVAR(turretPath), _turretPath];
+                _ctrlTurretMirrored call FUNC(handleTurretButton);
+            };
+        } forEach (_display getVariable QGVAR(controls));
+    };
+};
+
+// Update the button's icon and tooltip
+if (_turretPath isEqualTo []) then {
+    _ctrlTurret ctrlSetText ICON_DRIVER;
+    _ctrlTurret ctrlSetTooltip localize "STR_Driver";
+} else {
+    _ctrlTurret ctrlSetText ICON_GUNNER;
+    _ctrlTurret ctrlSetTooltip localize "STR_Gunner";
+};

--- a/addons/pylons/functions/script_component.hpp
+++ b/addons/pylons/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "\x\zen\addons\pylons\script_component.hpp"

--- a/addons/pylons/gui.hpp
+++ b/addons/pylons/gui.hpp
@@ -1,0 +1,83 @@
+class RscText;
+class RscButtonMenuOK;
+class RscButtonMenuCancel;
+
+class ctrlCombo;
+class ctrlStatic;
+class ctrlCheckbox;
+class ctrlStaticBackground;
+class ctrlStaticPictureKeepAspect;
+
+class GVAR(display) {
+    idd = -1;
+    movingEnable = 1;
+    onLoad = QUOTE(uiNamespace setVariable [ARR_2(QQGVAR(display),_this select 0)]);
+    class controls {
+        class Title: RscText {
+            idc = IDC_TITLE;
+            x = CENTER_X - (PICTURE_W + GRID_W(5)) / 2;
+            y = CENTER_Y - (PICTURE_H + GRID_H(22)) / 2;
+            w = PICTURE_W + GRID_W(5);
+            h = GRID_H(5);
+            colorBackground[] = GUI_THEME_COLOR;
+            moving = 1;
+        };
+        class Background: RscText {
+            idc = -1;
+            x = CENTER_X - (PICTURE_W + GRID_W(5)) / 2;
+            y = CENTER_Y - (PICTURE_H + GRID_H(11)) / 2;
+            w = PICTURE_W + GRID_W(5);
+            h = PICTURE_H + GRID_H(11);
+            colorBackground[] = {0, 0, 0, 0.7};
+        };
+        class PictureBackground: ctrlStaticBackground {
+            idc = -1;
+            x = CENTER_X - PICTURE_W / 2;
+            y = CENTER_Y - (PICTURE_H + GRID_H(6)) / 2;
+            w = PICTURE_W;
+            h = PICTURE_H;
+        };
+        class Picture: ctrlStaticPictureKeepAspect {
+            idc = IDC_PICTURE;
+            x = CENTER_X - PICTURE_W / 2;
+            y = CENTER_Y - (PICTURE_H + GRID_H(6)) / 2;
+            w = PICTURE_W;
+            h = PICTURE_H;
+        };
+        class Presets: ctrlCombo {
+            idc = IDC_PRESETS;
+            x = CENTER_X - PICTURE_W / 2;
+            y = CENTER_Y + (PICTURE_H + GRID_H(6)) / 2 - GRID_H(5);
+            w = PICTURE_W / 3;
+            h = GRID_H(5);
+        };
+        class MirrorLabel: ctrlStatic {
+            style = ST_RIGHT;
+            text = "$STR_3DEN_Object_Attribute_PylonsMirror_displayName";
+			tooltip = "$STR_3DEN_Object_Attribute_PylonsMirror_tooltip";
+            x = CENTER_X + PICTURE_W / 2 - GRID_W(35);
+            y = CENTER_Y + (PICTURE_H + GRID_H(6)) / 2 - GRID_H(5);
+            w = GRID_W(30);
+            h = GRID_H(5);
+        };
+        class Mirror: ctrlCheckbox {
+            idc = IDC_MIRROR;
+            x = CENTER_X + PICTURE_W / 2 - GRID_W(5);
+            y = CENTER_Y + (PICTURE_H + GRID_H(6)) / 2 - GRID_H(5);
+            w = GRID_W(5);
+            h = GRID_H(5);
+        };
+        class ButtonOK: RscButtonMenuOK {
+            x = CENTER_X + (PICTURE_W + GRID_W(5)) / 2 - GRID_W(25);
+            y = CENTER_Y + (PICTURE_H + GRID_H(22)) / 2 - GRID_H(5);
+            w = GRID_W(25);
+            h = GRID_H(5);
+        };
+        class ButtonCancel: RscButtonMenuCancel {
+            x = CENTER_X - (PICTURE_W + GRID_W(5)) / 2;
+            y = CENTER_Y + (PICTURE_H + GRID_H(22)) / 2 - GRID_H(5);
+            w = GRID_W(25);
+            h = GRID_H(5);
+        };
+    };
+};

--- a/addons/pylons/gui.hpp
+++ b/addons/pylons/gui.hpp
@@ -54,7 +54,7 @@ class GVAR(display) {
         class MirrorLabel: ctrlStatic {
             style = ST_RIGHT;
             text = "$STR_3DEN_Object_Attribute_PylonsMirror_displayName";
-			tooltip = "$STR_3DEN_Object_Attribute_PylonsMirror_tooltip";
+            tooltip = "$STR_3DEN_Object_Attribute_PylonsMirror_tooltip";
             x = CENTER_X + PICTURE_W / 2 - GRID_W(35);
             y = CENTER_Y + (PICTURE_H + GRID_H(6)) / 2 - GRID_H(5);
             w = GRID_W(30);

--- a/addons/pylons/script_component.hpp
+++ b/addons/pylons/script_component.hpp
@@ -1,0 +1,51 @@
+#define COMPONENT pylons
+#define COMPONENT_BEAUTIFIED Pylons
+#include "\x\zen\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_PYLONS
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_PYLONS
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_PYLONS
+#endif
+
+#include "\x\zen\addons\main\script_macros.hpp"
+
+#include "\a3\ui_f\hpp\defineDIKCodes.inc"
+#include "\x\zen\addons\common\defineResinclDesign.inc"
+
+#define IDC_PICTURE 800
+#define IDC_PRESETS 810
+#define IDC_MIRROR  820
+
+#define ICON_DRIVER "\a3\ui_f\data\igui\cfg\commandbar\imagedriver_ca.paa"
+#define ICON_GUNNER "\a3\ui_f\data\igui\cfg\commandbar\imagegunner_ca.paa"
+
+#define ICON_JETS "\a3\data_f_jets\logos\jets_logo_small_ca.paa"
+
+// Using pixel grid system in order to match the 3DEN pylons UI
+#define GRID_W(N) ((N) * pixelW * pixelGrid * 0.5)
+#define GRID_H(N) ((N) * pixelH * pixelGrid * 0.5)
+
+#define CENTER_X ((getResolution select 2) * 0.5 * pixelW)
+#define CENTER_Y ((getResolution select 3) * 0.5 * pixelH)
+
+// The pylons UIposition config entry is not used as a direct ratio of the picture's width/height
+// UIposition = {1, 1} does not correspond to the bottom-right of the image
+// Instead, there seems to be an extra scaling factor involved and very little information exists about this
+// Below are experimentally determined values to match as closely as possible the 3DEN pylons UI
+#define PICTURE_W GRID_W(124.2)
+#define PICTURE_H GRID_H(69.9)
+
+#define SCALE_FACTOR_X 1.25
+#define SCALE_FACTOR_Y 1.6667
+
+// Used to exit LBSelChanged event handler code triggered by the lbSetCurSel command
+#define LOCK GVAR(lock) = true
+#define UNLOCK GVAR(lock) = nil
+#define EXIT_LOCKED if (!isNil QGVAR(lock)) exitWith {}

--- a/addons/pylons/stringtable.xml
+++ b/addons/pylons/stringtable.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="ZEN">
+    <Package name="Pylons">
+        <Key ID="STR_ZEN_Pylons_DisplayName">
+            <English>Pylons</English>
+        </Key>
+        <Key ID="STR_ZEN_Pylons_Title">
+            <English>Configure Pylons (%1)</English>
+        </Key>
+        <Key ID="STR_ZEN_Pylons_Empty">
+            <English>&lt;Empty&gt;</English>
+        </Key>
+    </Package>
+</Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Add display to configure the pylon loadouts of aircraft, Close #143 
- Correctly uses the `UIposition` config entry to ensure pylon controls are positioned on the UI picture the same as 3DEN
- Wiki says `setPylonLoadout` command is EL but from testing command seems to be AL EG

<details>
<summary>Image</summary>

![pylons](https://user-images.githubusercontent.com/34453221/86555547-ad8f5f80-bf1e-11ea-8ad9-e043b1e22e9a.png)

</details>