### PR TITLE
Fix Teleport Zeus context menu action when player is in a vehicle

### DIFF
--- a/addons/context_actions/functions/fnc_teleportZeus.sqf
+++ b/addons/context_actions/functions/fnc_teleportZeus.sqf
@@ -18,5 +18,10 @@
 if (_hoveredEntity isEqualType objNull && {_hoveredEntity isKindOf "AllVehicles"} && {!(_hoveredEntity isKindOf "CAManBase")}) then {
     [[player], _hoveredEntity] call EFUNC(common,teleportIntoVehicle);
 } else {
-    player setPosASL _position;
+    if (vehicle player != player) then {
+        moveOut player;
+    };
+
+    player setVelocity [0, 0, 0];
+    player setVehiclePosition [ASLToATL _position, [], 0, "NONE"];
 };


### PR DESCRIPTION
**When merged this pull request will:**
- title, sometimes did not work if player was in a vehicle turret