### PR TITLE
Optimize enableAI/disableAI target events

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -109,13 +109,27 @@
 }] call CBA_fnc_addEventHandler;
 
 [QGVAR(enableAI), {
-    params ["_unit", "_section"];
-    _unit enableAI _section;
+    params ["_unit", "_sections"];
+
+    if (_sections isEqualType "") then {
+        _sections = [_sections];
+    };
+
+    {
+        _unit enableAI _x;
+    } forEach _sections;
 }] call CBA_fnc_addEventHandler;
 
 [QGVAR(disableAI), {
-    params ["_unit", "_section"];
-    _unit disableAI _section;
+    params ["_unit", "_sections"];
+
+    if (_sections isEqualType "") then {
+        _sections = [_sections];
+    };
+
+    {
+        _unit disableAI _x;
+    } forEach _sections;
 }] call CBA_fnc_addEventHandler;
 
 [QGVAR(doMove), {

--- a/addons/modules/functions/fnc_moduleAmbientAnimEnd.sqf
+++ b/addons/modules/functions/fnc_moduleAmbientAnimEnd.sqf
@@ -30,9 +30,7 @@ _unit removeEventHandler ["FiredNear", _firedNearEH];
 // If unit is alive then re-enable AI intelligence and switch to previous animation
 // If unit died, switch to the unit's death animation
 if (alive _unit) then {
-    {
-        [QEGVAR(common,enableAI), [_unit, _x], _unit] call CBA_fnc_targetEvent;
-    } forEach ["ANIM", "AUTOTARGET", "FSM", "MOVE", "TARGET"];
+    [QEGVAR(common,enableAI), [_unit, ["ANIM", "AUTOTARGET", "FSM", "MOVE", "TARGET"]], _unit] call CBA_fnc_targetEvent;
 
     // Try playMoveNow first, use switchMove if animation does not respond
     private _previousAnim = _unit getVariable [QGVAR(ambientAnimStart), ""];

--- a/addons/modules/functions/fnc_moduleAmbientAnimStart.sqf
+++ b/addons/modules/functions/fnc_moduleAmbientAnimStart.sqf
@@ -139,7 +139,7 @@ private _animations = switch (_animationType) do {
     };
     case 23: { // PRONE_INJURED_NO_WEAP_1, PRONE_INJURED_NO_WEAP_2
         selectRandom [
-            ["ainjppnemstpsnonwnondnon"], 
+            ["ainjppnemstpsnonwnondnon"],
             ["hubwoundedprone_idle1", "hubwoundedprone_idle2"]
         ]
     };
@@ -221,9 +221,7 @@ _unit setVariable [QGVAR(ambientAnimList), _animations];
 _unit setVariable [QGVAR(ambientAnimStart), animationState _unit];
 
 // Disable AI intelligence to prevent animation interrupt
-{
-    [QEGVAR(common,disableAI), [_unit, _x], _unit] call CBA_fnc_targetEvent;
-} forEach ["ANIM", "AUTOTARGET", "FSM", "MOVE", "TARGET"];
+[QEGVAR(common,disableAI), [_unit, ["ANIM", "AUTOTARGET", "FSM", "MOVE", "TARGET"]], _unit] call CBA_fnc_targetEvent;
 
 // Play a random animation to start the ambient animation loop
 [QEGVAR(common,switchMove), [_unit, selectRandom _animations]] call CBA_fnc_globalEvent;
@@ -246,6 +244,7 @@ private _killedEH = _unit addMPEventHandler ["MPKilled", {
         _this call FUNC(moduleAmbientAnimEnd);
     };
 }];
+
 _unit setVariable [QGVAR(ambientAnimKilledEH), _killedEH];
 
 // Add event handler to cancel animation if fired near and combat ready enabled
@@ -259,5 +258,6 @@ if (_combatReady) then {
             };
         }, _this, COMBAT_REACTION_DELAY] call CBA_fnc_waitAndExecute;
     }];
+
     _unit setVariable [QGVAR(ambientAnimFiredNearEH), _firedNearEH];
 };


### PR DESCRIPTION
**When merged this pull request will:**
- title, 1 target event instead of 5 in ambient animation module start and end
- Improve common `enableAI`/`disableAI` events to handle an array of AI sections instead of just one
