### PR TITLE
Fix script error for incorrectly configured aircraft

### DIFF
--- a/addons/modules/functions/fnc_compileAircraft.sqf
+++ b/addons/modules/functions/fnc_compileAircraft.sqf
@@ -22,7 +22,7 @@ private _aircraftCache = [];
 
     if (getNumber (_x >> "scope") == 2 && {_className isKindOf "Air"}) then {
         // Switch BLUFOR and OPFOR side IDs
-        private _side = [1, 0, 2, 3] select getNumber (_x >> "side");
+        private _side = [1, 0, 2, 3] param [getNumber (_x >> "side"), 3];
 
         // Get the side's faction hash which maps factions to lists of aircraft
         private _factions = _aircraftCache param [_side];


### PR DESCRIPTION
Some mods misconfigure their vehicles in such a way that causes a script error in ZEN as it only expects to see properly configured sides for public scoped vehicles. i.e. `LIB_La7_base` which has a side of 4 (Neutral)

**When merged this pull request will:**
- Fix the following script error by defaulting to civilian for unknown/weird side values.
```
 3:15:26 Error in expression <call CBA_fnc_hashCreate;
_aircraftCache set [_side, _factions];
};


private _fa>
 3:15:26   Error position: <set [_side, _factions];
};


private _fa>
 3:15:26   Error Type Any, expected Number
 3:15:26 File x\zen\addons\modules\functions\fnc_compileAircraft.sqf..., line 32
 3:15:26 Error in expression <);


private _factions = _aircraftCache param [_side];

if (isNil "_factions") t>
 3:15:26   Error position: <param [_side];

if (isNil "_factions") t>
 3:15:26   Error Type Any, expected Number
 3:15:26 File x\zen\addons\modules\functions\fnc_compileAircraft.sqf..., line 28
```
