### PR TITLE
Add Door State context menu action

### DIFF
--- a/addons/doors/CfgContext.hpp
+++ b/addons/doors/CfgContext.hpp
@@ -1,0 +1,8 @@
+class EGVAR(context_menu,actions) {
+    class GVAR(state) {
+        displayName = CSTRING(DoorState);
+        icon = ICON_DOOR;
+        insertChildren = QUOTE(call FUNC(getActions));
+        priority = 100;
+    };
+};

--- a/addons/doors/CfgVehicles.hpp
+++ b/addons/doors/CfgVehicles.hpp
@@ -5,7 +5,7 @@ class CfgVehicles {
         curatorCanAttach = 1;
         category = QEGVAR(modules,Buildings);
         displayName = CSTRING(Configure);
-        icon = "\a3\ui_f\data\igui\cfg\actions\open_door_ca.paa";
+        icon = ICON_DOOR;
         function = QFUNC(module);
     };
 };

--- a/addons/doors/XEH_PREP.hpp
+++ b/addons/doors/XEH_PREP.hpp
@@ -1,4 +1,5 @@
 PREP(configure);
+PREP(getActions);
 PREP(getDoors);
 PREP(getState);
 PREP(module);

--- a/addons/doors/config.cpp
+++ b/addons/doors/config.cpp
@@ -20,6 +20,7 @@ PRELOAD_ADDONS;
 
 #include "CfgEventHandlers.hpp"
 #include "CfgVehicles.hpp"
+#include "CfgContext.hpp"
 
 class RscActivePicture;
 class GVAR(RscActivePicture): RscActivePicture {

--- a/addons/doors/functions/fnc_configure.sqf
+++ b/addons/doors/functions/fnc_configure.sqf
@@ -28,17 +28,12 @@ if (_doors isEqualTo []) exitWith {
 private _display = findDisplay IDD_RSCDISPLAYCURATOR;
 private _controls = [];
 
-private _fnc_buttonClicked = {
-    params ["_control"];
-    (_control getVariable QGVAR(params)) params ["_building", "_door"];
-
-    [_building, _door] call FUNC(setState);
-};
-
 {
     private _control = _display ctrlCreate [QGVAR(RscActivePicture), -1];
-    _control ctrlAddEventHandler ["ButtonClick", _fnc_buttonClicked];
-    _control setVariable [QGVAR(params), [_building, _forEachIndex + 1]];
+
+    [_control, "ButtonClick", {
+        _thisArgs call FUNC(setState);
+    }, [_building, _forEachIndex + 1]] call CBA_fnc_addBISEventHandler;
 
     _controls pushBack _control;
 } forEach _doors;

--- a/addons/doors/functions/fnc_configure.sqf
+++ b/addons/doors/functions/fnc_configure.sqf
@@ -28,11 +28,17 @@ if (_doors isEqualTo []) exitWith {
 private _display = findDisplay IDD_RSCDISPLAYCURATOR;
 private _controls = [];
 
+private _fnc_buttonClicked = {
+    params ["_control"];
+    (_control getVariable QGVAR(params)) params ["_building", "_door"];
+
+    [_building, _door] call FUNC(setState);
+};
+
 {
     private _control = _display ctrlCreate [QGVAR(RscActivePicture), -1];
-    _control ctrlAddEventHandler ["ButtonClick", {call FUNC(setState)}];
-    _control setVariable [QGVAR(building), _building];
-    _control setVariable [QGVAR(door), _forEachIndex + 1];
+    _control ctrlAddEventHandler ["ButtonClick", _fnc_buttonClicked];
+    _control setVariable [QGVAR(params), [_building, _forEachIndex + 1]];
 
     _controls pushBack _control;
 } forEach _doors;

--- a/addons/doors/functions/fnc_getActions.sqf
+++ b/addons/doors/functions/fnc_getActions.sqf
@@ -46,7 +46,7 @@ if (_doors isEqualTo []) exitWith {
 
 // Calculate the distance from every door to the intersection position
 private _buildingPos = _building worldToModel ASLtoAGL _intersectPos;
-private _distances = _doors apply {_x distance _buildingPos};
+private _distances = _doors apply {_x vectorDistance _buildingPos};
 
 // Exit if the closest door is too far away from the intersection position
 private _minDistance = selectMin _distances;

--- a/addons/doors/functions/fnc_getActions.sqf
+++ b/addons/doors/functions/fnc_getActions.sqf
@@ -69,9 +69,7 @@ private _actions = [];
         _name,
         _icon,
         {
-            _args params ["_building", "_door", "_state"];
-
-            [_building, _door, _state] call FUNC(setState);
+            _args call FUNC(setState);
         },
         {true},
         [_building, _door, _state]

--- a/addons/doors/functions/fnc_getActions.sqf
+++ b/addons/doors/functions/fnc_getActions.sqf
@@ -1,0 +1,87 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Returns children actions for setting the state of a door.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * Actions <ARRAY>
+ *
+ * Example:
+ * [] call zen_doors_fnc_getActions
+ *
+ * Public: No
+ */
+
+#define MAX_SCAN_DISTANCE 100
+#define MAX_DOOR_DISTANCE 1.5
+
+// Check if the cursor is hovering over a building's door by checking intersections from the camera
+private _begPos = getPosASL curatorCamera;
+private _endPos = AGLtoASL screenToWorld getMousePosition;
+
+// Limit the intersection scan distance to prevent interaction with far away buildings
+// Also improves performance of intersection test which can be expensive at long distances
+if (_begPos distance _endPos > MAX_SCAN_DISTANCE) then {
+    _endPos = _begPos vectorAdd (_begPos vectorFromTo _endPos vectorMultiply MAX_SCAN_DISTANCE);
+};
+
+private _intersections = lineIntersectsSurfaces [_begPos, _endPos, objNull, objNull, true, 1, "GEOM"];
+_intersections param [0, []] params [["_intersectPos", [0, 0, 0]], "", ["_building", objNull]];
+
+// Exit if there was no intersection or if it was with terrain
+if (isNull _building) exitWith {
+    [] // No children actions
+};
+
+// Get the door positions of the building
+private _doors = [_building] call FUNC(getDoors);
+
+// Exit if the building has no doors
+if (_doors isEqualTo []) exitWith {
+    [] // No children actions
+};
+
+// Calculate the distance from every door to the intersection position
+private _buildingPos = _building worldToModel ASLtoAGL _intersectPos;
+private _distances = _doors apply {_x distance _buildingPos};
+
+// Exit if the closest door is too far away from the intersection position
+private _minDistance = selectMin _distances;
+
+if (_minDistance > MAX_DOOR_DISTANCE) exitWith {
+    [] // No children actions
+};
+
+// Find the index of the closest door
+private _door = (_distances find _minDistance) + 1;
+
+// Create closed, locked, and opened actions for the closest door
+private _actions = [];
+
+{
+    _x params ["_name", "_icon", "_state"];
+
+    private _action = [
+        format [QGVAR(%1), _state],
+        _name,
+        _icon,
+        {
+            _args params ["_building", "_door", "_state"];
+
+            [_building, _door, _state] call FUNC(setState);
+        },
+        {true},
+        [_building, _door, _state]
+    ] call EFUNC(context_menu,createAction);
+
+    _actions pushBack [_action, [], 0];
+} forEach [
+    [TEXT_CLOSED, ICON2D_CLOSED, STATE_CLOSED],
+    [TEXT_LOCKED, ICON2D_LOCKED, STATE_LOCKED],
+    [TEXT_OPENED, ICON2D_OPENED, STATE_OPENED]
+];
+
+_actions

--- a/addons/doors/functions/fnc_getState.sqf
+++ b/addons/doors/functions/fnc_getState.sqf
@@ -18,6 +18,6 @@
 
 params ["_building", "_door"];
 
-if (_building getVariable [LOCKED_VAR(_door), 0] == 1) exitWith {STATE_LOCKED};
+if (_building getVariable [VAR_LOCKED(_door), 0] == 1) exitWith {STATE_LOCKED};
 
 [STATE_CLOSED, STATE_OPENED] select (_building animationSourcePhase ANIM_NAME_1(_door) > 0.5)

--- a/addons/doors/functions/fnc_setState.sqf
+++ b/addons/doors/functions/fnc_setState.sqf
@@ -1,28 +1,31 @@
 #include "script_component.hpp"
 /*
  * Author: mharis001
- * Cycles the state of a door. Called from the door button click EH.
+ * Sets the state of the given door for the given building.
+ * If a state is not specified, the door's state is cycled.
  *
  * Arguments:
- * 0: Door Button <CONTROL>
+ * 0: Building <OBJECT>
+ * 1: Door Index <NUMBER>
+ * 2: State <NUMBER>
  *
  * Return Value:
  * None
  *
  * Example:
- * [CONTROL] call zen_doors_fnc_setState
+ * [_building, _door, 0] call zen_doors_fnc_setState
  *
  * Public: No
  */
 
-params ["_control"];
+params ["_building", "_door", "_state"];
 
-private _building = _control getVariable QGVAR(building);
-private _door     = _control getVariable QGVAR(door);
+// If no state is given, switch the door to the next state (closed -> locked -> opened)
+if (isNil "_state") then {
+    _state = [_building, _door] call FUNC(getState);
+    _state = [STATE_LOCKED, STATE_OPENED, STATE_CLOSED] select _state;
+};
 
-private _state = [_building, _door] call FUNC(getState);
-_state = floor ((_state + 1) % 3);
-
-_building setVariable [LOCKED_VAR(_door), [0, 1, 0] select _state, true];
+_building setVariable [VAR_LOCKED(_door), [0, 1, 0] select _state, true];
 _building animateSource [ANIM_NAME_1(_door), [0, 0, 1] select _state, false];
 _building animateSource [ANIM_NAME_2(_door), [0, 0, 1] select _state, false];

--- a/addons/doors/functions/fnc_updatePFH.sqf
+++ b/addons/doors/functions/fnc_updatePFH.sqf
@@ -48,7 +48,7 @@ if (curatorCamera distance _building > DISTANCE_CANCEL) exitWith {
         _control ctrlShow true;
 
         private _state = [_building, _forEachIndex + 1] call FUNC(getState);
-        private _icon  = [ICON_CLOSED, ICON_LOCKED, ICON_OPENED] select _state;
+        private _icon  = [ICON3D_CLOSED, ICON3D_LOCKED, ICON3D_OPENED] select _state;
         private _color = [COLOR_CLOSED, COLOR_LOCKED, COLOR_OPENED] select _state;
 
         _control ctrlSetText _icon;

--- a/addons/doors/script_component.hpp
+++ b/addons/doors/script_component.hpp
@@ -26,9 +26,9 @@
 
 #define ICON_DOOR "\a3\ui_f\data\igui\cfg\actions\open_door_ca.paa"
 
-#define TEXT_CLOSED (localize "STR_a3_to_editTerrainObject21")
-#define TEXT_LOCKED (localize "STR_a3_to_editTerrainObject23")
-#define TEXT_OPENED (localize "STR_a3_to_editTerrainObject22")
+#define TEXT_CLOSED localize "STR_a3_to_editTerrainObject21"
+#define TEXT_LOCKED localize "STR_a3_to_editTerrainObject23"
+#define TEXT_OPENED localize "STR_a3_to_editTerrainObject22"
 
 #define ICON2D_CLOSED "\a3\modules_f\data\editterrainobject\texturedoor_closed_ca.paa"
 #define ICON2D_LOCKED "\a3\modules_f\data\editterrainobject\texturedoor_locked_ca.paa"

--- a/addons/doors/script_component.hpp
+++ b/addons/doors/script_component.hpp
@@ -46,10 +46,10 @@
 #define STATE_LOCKED 1
 #define STATE_OPENED 2
 
-#define VAR_LOCKED(door) format ["bis_disabled_door_%1", door]
+#define VAR_LOCKED(x) format ["bis_disabled_door_%1", x]
 
-#define ANIM_NAME_1(door) format ["door_%1_sound_source", door]
-#define ANIM_NAME_2(door) format ["door_%1_noSound_source", door]
+#define ANIM_NAME_1(x) format ["door_%1_sound_source", x]
+#define ANIM_NAME_2(x) format ["door_%1_noSound_source", x]
 
 #define DISTANCE_DRAW   100
 #define DISTANCE_CANCEL 200

--- a/addons/doors/script_component.hpp
+++ b/addons/doors/script_component.hpp
@@ -24,9 +24,19 @@
 #define POS_W(N) ((N) * GUI_GRID_W)
 #define POS_H(N) ((N) * GUI_GRID_H)
 
-#define ICON_CLOSED "\a3\modules_f\data\editterrainobject\icon3d_doorclosed32_ca.paa"
-#define ICON_LOCKED "\a3\modules_f\data\editterrainobject\icon3d_doorlocked32_ca.paa"
-#define ICON_OPENED "\a3\modules_f\data\editterrainobject\icon3d_dooropened32_ca.paa"
+#define ICON_DOOR "\a3\ui_f\data\igui\cfg\actions\open_door_ca.paa"
+
+#define TEXT_CLOSED (localize "STR_a3_to_editTerrainObject21")
+#define TEXT_LOCKED (localize "STR_a3_to_editTerrainObject23")
+#define TEXT_OPENED (localize "STR_a3_to_editTerrainObject22")
+
+#define ICON2D_CLOSED "\a3\modules_f\data\editterrainobject\texturedoor_closed_ca.paa"
+#define ICON2D_LOCKED "\a3\modules_f\data\editterrainobject\texturedoor_locked_ca.paa"
+#define ICON2D_OPENED "\a3\modules_f\data\editterrainobject\texturedoor_opened_ca.paa"
+
+#define ICON3D_CLOSED "\a3\modules_f\data\editterrainobject\icon3d_doorclosed32_ca.paa"
+#define ICON3D_LOCKED "\a3\modules_f\data\editterrainobject\icon3d_doorlocked32_ca.paa"
+#define ICON3D_OPENED "\a3\modules_f\data\editterrainobject\icon3d_dooropened32_ca.paa"
 
 #define COLOR_CLOSED [1, 1, 1, 1]
 #define COLOR_LOCKED [1, 0, 1, 1]
@@ -36,10 +46,10 @@
 #define STATE_LOCKED 1
 #define STATE_OPENED 2
 
-#define LOCKED_VAR(DOOR) (format ["bis_disabled_door_%1", DOOR])
+#define VAR_LOCKED(door) format ["bis_disabled_door_%1", door]
 
-#define ANIM_NAME_1(DOOR) (format ["door_%1_sound_source", DOOR])
-#define ANIM_NAME_2(DOOR) (format ["door_%1_noSound_source", DOOR])
+#define ANIM_NAME_1(door) format ["door_%1_sound_source", door]
+#define ANIM_NAME_2(door) format ["door_%1_noSound_source", door]
 
 #define DISTANCE_DRAW   100
 #define DISTANCE_CANCEL 200

--- a/addons/doors/stringtable.xml
+++ b/addons/doors/stringtable.xml
@@ -10,6 +10,9 @@
             <Japanese>ドア設定</Japanese>
             <Korean>문 설정</Korean>
         </Key>
+        <Key ID="STR_ZEN_Doors_DoorState">
+            <English>Door State</English>
+        </Key>
         <Key ID="STR_ZEN_Doors_NoBuilding">
             <English>Place on a building</English>
             <French>Placer sur un bâtiment</French>

--- a/docs/user_guide/context_actions.md
+++ b/docs/user_guide/context_actions.md
@@ -23,7 +23,12 @@ Applies the selected combat mode to all currently selected groups.
 ## Create Area Marker
 
 Creates an [area marker](/user_guide/area_markers.md) at the context menu's position.
-This context menu must be opened on the map.
+Available only when the context menu is opened on the map.
+
+## Door State
+
+Sets the state of the selected door (closed, locked, opened).
+Available when the context menu is opened with the cursor hovering over a door.
 
 ## Editable Objects
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add a context menu action that allows users to open context menu while hovering over a door and set its state
- Minor cleanup of `doors` component

<details>
<summary>Image</summary>

![door_context_menu](https://user-images.githubusercontent.com/34453221/102595467-9d8ec500-40e5-11eb-9adf-6970a9fc2aed.png)


</details>