### PR TITLE
Add Saved selection for modules and Transfer Ownership Module

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -314,8 +314,36 @@ if (isServer) then {
     }] call CBA_fnc_addEventHandler;
 
     [QGVAR(enableSimulationGlobal), {
+        diag_log _this;
         params ["_object", "_enable"];
         _object enableSimulationGlobal _enable;
+    }] call CBA_fnc_addEventHandler;
+
+    [QGVAR(transferOwnership), {
+        diag_log QGVAR(transferOwnership);
+        diag_log _this;
+        params ["_entities", "_target"];
+        if (!(_entities isEqualType [])) then {
+            _entities = [_entities];
+        };
+        private _clientID = 0;
+        if (_target isEqualType 0) then {
+            _clientID = _target;
+        };
+        if (_target isEqualType objNull) then {
+            _clientID = owner _target;
+        };
+        {
+            if (_x isEqualType grpNull) then {
+                _x setGroupOwner _clientID;
+            } else {
+                if (group _x == grpNull) then {
+                    group _x setGroupOwner _clientID;
+                } else {
+                    _x setOwner _clientID;
+                };
+            };
+        } forEach _entities;
     }] call CBA_fnc_addEventHandler;
 
     [QGVAR(setFriend), {

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -314,14 +314,11 @@ if (isServer) then {
     }] call CBA_fnc_addEventHandler;
 
     [QGVAR(enableSimulationGlobal), {
-        diag_log _this;
         params ["_object", "_enable"];
         _object enableSimulationGlobal _enable;
     }] call CBA_fnc_addEventHandler;
 
     [QGVAR(transferOwnership), {
-        diag_log QGVAR(transferOwnership);
-        diag_log _this;
         params ["_entities", "_target"];
         if (!(_entities isEqualType [])) then {
             _entities = [_entities];

--- a/addons/editor/XEH_PREP.hpp
+++ b/addons/editor/XEH_PREP.hpp
@@ -1,5 +1,6 @@
 PREP(addGroupIcons);
 PREP(declutterEmptyTree);
+PREP(drawSavedSelectionIcons);
 PREP(fixSideButtons);
 PREP(handleKeyDown);
 PREP(handleLoad);
@@ -9,6 +10,7 @@ PREP(handleSearchButton);
 PREP(handleSearchClick);
 PREP(handleSearchKeyDown);
 PREP(handleSearchKeyUp);
+PREP(handleSelectionChanged);
 PREP(handleSideButtons);
 PREP(handleTreeButtons);
 PREP(handleUnload);

--- a/addons/editor/XEH_preInit.sqf
+++ b/addons/editor/XEH_preInit.sqf
@@ -9,6 +9,9 @@ PREP_RECOMPILE_END;
 #include "initSettings.sqf"
 #include "initKeybinds.sqf"
 
+GVAR(lastSelection) = [];
+GVAR(savedSelection) = [];
+GVAR(colour) = ["IGUI", "TEXT_RGB"] call BIS_fnc_displayColorGet;
 GVAR(clipboard) = [];
 GVAR(includeCrew) = true;
 
@@ -16,6 +19,10 @@ GVAR(includeCrew) = true;
     params ["_logic"];
 
     _logic addEventHandler ["CuratorObjectPlaced", {call FUNC(handleObjectPlaced)}];
+    _logic addEventHandler ["CuratorGroupSelectionChanged", {call FUNC(handleSelectionChanged)}];
+    _logic addEventHandler ["CuratorMarkerSelectionChanged", {call FUNC(handleSelectionChanged)}];
+    _logic addEventHandler ["CuratorObjectSelectionChanged", {call FUNC(handleSelectionChanged)}];
+    _logic addEventHandler ["CuratorWaypointSelectionChanged", {call FUNC(handleSelectionChanged)}];
 }, true, [], true] call CBA_fnc_addClassEventHandler;
 
 ADDON = true;

--- a/addons/editor/functions/fnc_drawSavedSelectionIcons.sqf
+++ b/addons/editor/functions/fnc_drawSavedSelectionIcons.sqf
@@ -1,0 +1,33 @@
+#include "script_component.hpp"
+/*
+ * Author: Ampersand
+ * Draws icons over saved selection entities.
+ *
+ * Arguments:
+ * 0: Icon <STRING>
+ *
+ * Return Value:
+ * 0: Draw3D mission EH handle <NUMBER>
+ *
+ * Example:
+ * ["\a3\ui_f\data\Map\VehicleIcons\iconVirtual_ca.paa"] call zen_editor_fnc_drawSavedSelectionIcons
+ *
+ * Public: No
+ */
+
+if (GVAR(savedSelection) select 0 isEqualTo []) exitWith {
+    -1
+};
+
+params ["_icon"];
+
+private _mehID = addMissionEventHandler ["Draw3D", {
+    {
+        drawIcon3D [
+            "\a3\ui_f\data\Map\VehicleIcons\iconVirtual_ca.paa",
+            GVAR(colour), getPos _x, 1, 1, 0
+        ];
+    } forEach (GVAR(savedSelection) select 0);
+}];
+
+_mehID

--- a/addons/editor/functions/fnc_handleSelectionChanged.sqf
+++ b/addons/editor/functions/fnc_handleSelectionChanged.sqf
@@ -1,0 +1,23 @@
+#include "script_component.hpp"
+/*
+ * Author: Ampersand
+ * Saves curator selected entities for use by modules.
+ *
+ * Arguments:
+ * 0: Curator <OBJECT>
+ * 0: Entity: group, marker, object, or waypoint <GROUP, STRING, OBJECT, ARRAY>
+ *
+ * Return Value:
+ * Handled <BOOL>
+ *
+ * Example:
+ * [CONTROL] call zen_editor_fnc_handleSelectionChanged
+ *
+ * Public: No
+ */
+
+params ["_curator", "_entity"];
+GVAR(savedSelection) = GVAR(lastSelection);
+GVAR(lastSelection) = curatorSelected;
+
+false

--- a/addons/modules/CfgVehicles.hpp
+++ b/addons/modules/CfgVehicles.hpp
@@ -422,6 +422,14 @@ class CfgVehicles {
         function = QFUNC(moduleToggleLamps);
         icon = QPATHTOF(ui\street_lamp_ca.paa);
     };
+    class GVAR(moduleTransferOwnership): GVAR(moduleBase) {
+        curatorCanAttach = 1;
+        category = QGVAR(DevTools);
+        displayName = CSTRING(ModuleTransferOwnership);
+        function = QFUNC(moduleTransferOwnership);
+        icon = "\a3\ui_f\data\Map\VehicleIcons\iconVirtual_ca.paa";
+        portrait = "\a3\ui_f\data\Map\VehicleIcons\iconVirtual_ca.paa";
+    };
     class GVAR(moduleTurretOptics): GVAR(moduleBase) {
         curatorCanAttach = 1;
         category = QGVAR(Equipment);

--- a/addons/modules/XEH_PREP.hpp
+++ b/addons/modules/XEH_PREP.hpp
@@ -80,6 +80,7 @@ PREP(moduleTeleportPlayers);
 PREP(moduleToggleFlashlights);
 PREP(moduleToggleIRLasers);
 PREP(moduleToggleLamps);
+PREP(moduleTransferOwnership);
 PREP(moduleTurretOptics);
 PREP(moduleUnGarrison);
 PREP(moduleVisibility);

--- a/addons/modules/config.cpp
+++ b/addons/modules/config.cpp
@@ -65,6 +65,7 @@ class CfgPatches {
             QGVAR(moduleToggleFlashlights),
             QGVAR(moduleToggleIRLasers),
             QGVAR(moduleToggleLamps),
+            QGVAR(ModuleTransferOwnership),
             QGVAR(moduleTurretOptics),
             QGVAR(moduleUnGarrison),
             QGVAR(moduleVisibility),

--- a/addons/modules/functions/fnc_moduleTransferOwnership.sqf
+++ b/addons/modules/functions/fnc_moduleTransferOwnership.sqf
@@ -1,0 +1,72 @@
+#include "script_component.hpp"
+/*
+ * Author: Ampersand
+ * Zeus module function to transfer ownership of objects.
+ *
+ * Arguments:
+ * 0: Logic <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [LOGIC] call zen_modules_fnc_moduleTransferOwnership
+ *
+ * Public: No
+ */
+
+if (!isMultiplayer) exitWith {
+ [LSTRING(OnlyMultiplayer)] call EFUNC(common,showMessage);
+};
+
+params ["_logic"];
+
+private _unit = attachedTo _logic;
+deleteVehicle _logic;
+
+private _clientTypes = allPlayers;
+private _clientNames = allPlayers apply {name _x};
+if (!isServer) then {
+    _clientTypes = [2] + _clientTypes;
+    _clientNames = ["Server"] + _clientNames;
+};
+
+private _entities = [];
+private _mehID = -1;
+if (isNull _unit) then {
+    _mehID = ["\a3\ui_f\data\Map\VehicleIcons\iconVirtual_ca.paa"] call EFUNC(editor,drawSavedSelectionIcons);
+    EGVAR(editor,savedSelection) params ["_objects", "_groups"];
+    {
+        if (isNull group _x) then {
+            _entities pushBack _x;
+        } else {
+            _groups pushBackUnique group _x;
+        };
+    } forEach _objects;
+    _entities append _groups;
+} else {
+    _entities = [[group _unit, _unit] select (isNull group _unit)];
+};
+
+[LSTRING(ModuleTransferOwnership), [
+    [
+        "COMBO",
+        ELSTRING(common,Target),
+        [_clientTypes, _clientNames, 0]
+    ]
+], {
+    params ["_values", "_args"];
+    _args params ["_entities", "_mehID"];
+    if (_mehID > 0) then {
+        removeMissionEventHandler ["Draw3D", _mehID];
+    };
+
+    _values params ["_target"];
+    [QEGVAR(common,transferOwnership), [_entities, _target]] call CBA_fnc_serverEvent;
+}, {
+    params ["", "_args"];
+    _args params ["", "_mehID"];
+    if (_mehID > 0) then {
+        removeMissionEventHandler ["Draw3D", _mehID];
+    };
+}, [_entities, _mehID]] call EFUNC(dialog,create);

--- a/addons/modules/functions/fnc_moduleTransferOwnership.sqf
+++ b/addons/modules/functions/fnc_moduleTransferOwnership.sqf
@@ -27,8 +27,8 @@ deleteVehicle _logic;
 private _clientTypes = allPlayers;
 private _clientNames = allPlayers apply {name _x};
 if (!isServer) then {
-    _clientTypes = [2] + _clientTypes;
-    _clientNames = ["Server"] + _clientNames;
+    _clientTypes = [0] + _clientTypes;
+    _clientNames = ["str_a3_om_common_definitions.incphone_44"] + _clientNames;
 };
 
 private _entities = [];
@@ -48,21 +48,41 @@ if (isNull _unit) then {
     _entities = [[group _unit, _unit] select (isNull group _unit)];
 };
 
+private _defaultTarget = !local (_entities select 0);
 [LSTRING(ModuleTransferOwnership), [
     [
-        "COMBO",
+        "TOOLBOX",
         ELSTRING(common,Target),
+        [_defaultTarget, 1, 3, [
+            LSTRING(ModuleTransferOwnership_Server),
+            "str_a3_cfgvehicles_module_f_moduledescription_curator_f_1",
+            LSTRING(ModuleTransferOwnership_Client)
+        ]]
+    ],
+    [
+        "COMBO",
+        LSTRING(ModuleTransferOwnership_Client),
         [_clientTypes, _clientNames, 0]
     ]
 ], {
     params ["_values", "_args"];
+    _values params ["_target", "_player"];
     _args params ["_entities", "_mehID"];
     if (_mehID > 0) then {
         removeMissionEventHandler ["Draw3D", _mehID];
     };
-
-    _values params ["_target"];
-    [QEGVAR(common,transferOwnership), [_entities, _target]] call CBA_fnc_serverEvent;
+    private _targetID = switch (_target) do {
+        case (0): {
+            2
+        };
+        case (1): {
+            clientOwner
+        };
+        case (2): {
+            _player
+        };
+    };
+    [QEGVAR(common,transferOwnership), [_entities, _targetID]] call CBA_fnc_serverEvent;
 }, {
     params ["", "_args"];
     _args params ["", "_mehID"];

--- a/addons/modules/stringtable.xml
+++ b/addons/modules/stringtable.xml
@@ -2216,6 +2216,9 @@
             <Korean>소환</Korean>
         </Key>
         <!-- Feedback Messages -->
+        <Key ID="STR_ZEN_Modules_SelectionCannotIncludePlayers">
+            <English>Selection cannot include players</English>
+        </Key>
         <Key ID="STR_ZEN_Modules_OnlyMultiplayer">
             <English>Module only available in multiplayer</English>
         </Key>

--- a/addons/modules/stringtable.xml
+++ b/addons/modules/stringtable.xml
@@ -590,6 +590,15 @@
             <Japanese>CAS - 爆撃</Japanese>
             <Korean>CAS - 폭탄 투하</Korean>
         </Key>
+        <Key ID="STR_ZEN_Modules_ModuleTransferOwnership">
+            <English>Transfer Ownership</English>
+        </Key>
+        <Key ID="STR_ZEN_Modules_ModuleTransferOwnership_Client">
+            <English>Client</English>
+        </Key>
+        <Key ID="STR_ZEN_Modules_ModuleTransferOwnership_Server">
+            <English>Server</English>
+        </Key>
         <Key ID="STR_ZEN_Modules_BindVariable">
             <English>Bind Variable To Object</English>
             <Russian>Привязать переменную к объекту</Russian>
@@ -2207,6 +2216,9 @@
             <Korean>소환</Korean>
         </Key>
         <!-- Feedback Messages -->
+        <Key ID="STR_ZEN_Modules_OnlyMultiplayer">
+            <English>Module only available in multiplayer</English>
+        </Key>
         <Key ID="STR_ZEN_Modules_NoUnitSelected">
             <English>Place on a unit</English>
             <French>Placez sur une unité</French>

--- a/docs/user_guide/modules_list.md
+++ b/docs/user_guide/modules_list.md
@@ -267,6 +267,10 @@ Toggles the simulation of the attached object.
 
 Toggles the visibility of the attached object.
 
+## Transfer Ownership
+
+Transfer locality of objects and groups between server and clients.
+
 ## Un-Garrison Group
 
 Un-garrisons units from the attached group.


### PR DESCRIPTION
**When merged this pull request will:**
- Add global variable `zen_editor_savedSelection` which tracks the previous-to-last content of `curatorSelected`, used for selecting entities then dropping a module affecting them.
- Add Transfer Ownership module using saved selection
- https://youtu.be/4L-czAJIIcQ