### PR TITLE
Add Faction Filter

### DIFF
--- a/addons/editor/functions/fnc_fixSideButtons.sqf
+++ b/addons/editor/functions/fnc_fixSideButtons.sqf
@@ -5,30 +5,30 @@
  *
  * Arguments:
  * 0: Display <DISPLAY>
- * 1: Mode <NUMBER>
  *
  * Return Value:
  * None
  *
  * Example:
- * [DISPLAY, 0] call zen_editor_fnc_fixSideButtons
+ * [DISPLAY] call zen_editor_fnc_fixSideButtons
  *
  * Public: No
  */
 
-[{
-    params ["_display", "_mode"];
+params ["_display"];
 
-    // Get side buttons to show based on mode
-    private _idcs = switch (_mode) do {
-        case 0;
-        case 1: {IDCS_SIDE_BUTTONS};
-        case 2;
-        case 3: {[IDC_RSCDISPLAYCURATOR_SIDEEMPTY]};
-        default {[]}
-    };
+private _sections = missionNamespace getVariable ["RscDisplayCurator_sections", [0, 0]];
+_sections params ["_mode"];
 
-    {
-        (_display displayCtrl _x) ctrlShow true;
-    } forEach _idcs;
-}, _this] call CBA_fnc_execNextFrame;
+// Get side buttons to show based on mode
+private _idcs = switch (_mode) do {
+    case 0;
+    case 1: {IDCS_SIDE_BUTTONS};
+    case 2;
+    case 3: {[IDC_RSCDISPLAYCURATOR_SIDEEMPTY]};
+    default {[]};
+};
+
+{
+    (_display displayCtrl _x) ctrlShow true;
+} forEach _idcs;

--- a/addons/editor/functions/fnc_handleLoad.sqf
+++ b/addons/editor/functions/fnc_handleLoad.sqf
@@ -137,8 +137,13 @@ GVAR(iconsVisible) = true;
 
         if (isNull _display) exitWith {};
 
+        [QGVAR(treesLoaded), _display] call CBA_fnc_localEvent;
+
         [_display] call FUNC(addGroupIcons);
         [_display] call FUNC(declutterEmptyTree);
+
+        // Initially fix side buttons (can be hidden if a tree has no entries)
+        [FUNC(fixSideButtons), _display] call CBA_fnc_execNextFrame;
 
         {
             private _ctrl = _display displayCtrl _x;

--- a/addons/editor/functions/fnc_handleModeButtons.sqf
+++ b/addons/editor/functions/fnc_handleModeButtons.sqf
@@ -15,12 +15,12 @@
  * Public: No
  */
 
+
+params ["_ctrlButton"];
+
+private _display = ctrlParent _ctrlButton;
+
 [{
-    params ["_ctrlButton"];
-
-    private _display = ctrlParent _ctrlButton;
-    private _mode = IDCS_MODE_BUTTONS find ctrlIDC _ctrlButton;
-    private _side = GETMVAR(RscDisplayCurator_sections,[]) param [1, 0];
-
-    [QGVAR(modeChanged), [_display, _mode, _side]] call CBA_fnc_localEvent;
-}, _this] call CBA_fnc_execNextFrame;
+    RscDisplayCurator_sections params ["_mode", "_side"];
+    [QGVAR(modeChanged), [_this, _mode, _side]] call CBA_fnc_localEvent;
+}, _display] call CBA_fnc_execNextFrame;

--- a/addons/editor/functions/fnc_handleSideButtons.sqf
+++ b/addons/editor/functions/fnc_handleSideButtons.sqf
@@ -20,9 +20,8 @@ params ["_ctrlButton"];
 if !(_ctrlButton getVariable [QGVAR(hovered), false]) exitWith {};
 
 private _display = ctrlParent _ctrlButton;
-private _mode = GETMVAR(RscDisplayCurator_sections,[]) param [0, 0];
-private _side = IDCS_SIDE_BUTTONS find ctrlIDC _ctrlButton;
 
 [{
-    [QGVAR(sideChanged), _this] call CBA_fnc_localEvent;
-}, [_display, _mode, _side]] call CBA_fnc_execNextFrame;
+    RscDisplayCurator_sections params ["_mode", "_side"];
+    [QGVAR(sideChanged), [_this, _mode, _side]] call CBA_fnc_localEvent;
+}, _display] call CBA_fnc_execNextFrame;

--- a/addons/faction_filter/$PBOPREFIX$
+++ b/addons/faction_filter/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\zen\addons\faction_filter

--- a/addons/faction_filter/CfgEventHandlers.hpp
+++ b/addons/faction_filter/CfgEventHandlers.hpp
@@ -1,0 +1,17 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+    };
+};
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
+    };
+};

--- a/addons/faction_filter/XEH_postInit.sqf
+++ b/addons/faction_filter/XEH_postInit.sqf
@@ -1,0 +1,64 @@
+#include "script_component.hpp"
+
+["CBA_SettingChanged", {
+    params ["_name"];
+
+    // Schedule the Zeus display to be reloaded when a faction filter setting is changed
+    // Allows for changing faction filter settings mid-mission while the interface is forced
+    if (QUOTE(ADDON) in _name && {!isNull findDisplay IDD_RSCDISPLAYCURATOR} && {isNil QGVAR(displayReload)}) then {
+        GVAR(displayReload) = true;
+
+        {
+            (findDisplay IDD_RSCDISPLAYCURATOR) closeDisplay IDC_CANCEL;
+
+            [{
+                isNull findDisplay IDD_RSCDISPLAYCURATOR
+            }, {
+                openCuratorInterface;
+                GVAR(displayReload) = nil;
+            }] call CBA_fnc_waitUntilAndExecute;
+        } call CBA_fnc_execNextFrame;
+    };
+}] call CBA_fnc_addEventHandler;
+
+[QEGVAR(editor,treesLoaded), {
+    BEGIN_COUNTER(processTrees);
+
+    params ["_display"];
+
+    private _fnc_processTrees = {
+        params ["_treeIDCs", "_basePath"];
+
+        {
+            private _ctrlTree = _display displayCtrl _x;
+
+            for "_i" from (_ctrlTree tvCount _basePath) - 1 to 0 step -1 do {
+                private _path = _basePath + [_i];
+                private _name = _ctrlTree tvText _path;
+
+                // Get the setting variable name that corresponds to this faction's name and side
+                private _varName = GVAR(map) getVariable [FACTION_ID(_forEachIndex,_name), ""];
+
+                if !(missionNamespace getVariable [_varName, true]) then {
+                    _ctrlTree tvDelete _path;
+                };
+            };
+        } forEach _treeIDCs;
+    };
+
+    [[
+        IDC_RSCDISPLAYCURATOR_CREATE_UNITS_EAST,
+        IDC_RSCDISPLAYCURATOR_CREATE_UNITS_WEST,
+        IDC_RSCDISPLAYCURATOR_CREATE_UNITS_GUER,
+        IDC_RSCDISPLAYCURATOR_CREATE_UNITS_CIV
+    ], []] call _fnc_processTrees;
+
+    [[
+        IDC_RSCDISPLAYCURATOR_CREATE_GROUPS_EAST,
+        IDC_RSCDISPLAYCURATOR_CREATE_GROUPS_WEST,
+        IDC_RSCDISPLAYCURATOR_CREATE_GROUPS_GUER,
+        IDC_RSCDISPLAYCURATOR_CREATE_GROUPS_CIV
+    ], [0]] call _fnc_processTrees;
+
+    END_COUNTER(processTrees);
+}] call CBA_fnc_addEventHandler;

--- a/addons/faction_filter/XEH_preInit.sqf
+++ b/addons/faction_filter/XEH_preInit.sqf
@@ -1,0 +1,20 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+// Create trees do not provide the faction class name that a given node represents
+// Only the faction's name and side can be obtained from the tree
+// This namespace maps a faction's name and side to its corresponding setting variable name
+GVAR(map) = [] call CBA_fnc_createNamespace;
+
+{
+    _x params ["_name", "_faction", "_side"];
+
+    private _varName = format [QGVAR(%1_%2), _side, _faction];
+    GVAR(map) setVariable [FACTION_ID(_side,_name), _varName];
+
+    private _sideName = ["str_east", "str_west", "str_guerrila", "str_civilian"] select _side;
+    [_varName, "CHECKBOX", _name, [LSTRING(DisplayName), _sideName], true, false] call CBA_fnc_addSetting;
+} forEach (uiNamespace getVariable QGVAR(factions));
+
+ADDON = true;

--- a/addons/faction_filter/XEH_preStart.sqf
+++ b/addons/faction_filter/XEH_preStart.sqf
@@ -1,0 +1,63 @@
+#include "script_component.hpp"
+
+private _factions = [];
+private _cfgVehicles = configFile >> "CfgVehicles";
+private _cfgFactionClasses = configFile >> "CfgFactionClasses";
+private _cfgEditorCategories = configFile >> "CfgEditorCategories";
+
+// Zeus only includes objects defined in the units array of CfgPatches classes
+{
+    {
+        // Classes that do not inherit from AllVehicles have thier side ignored and are considered props (Zeus also ignores animals)
+        if (_x isKindOf "AllVehicles" && {!(_x isKindOf "Animal")}) then {
+            private _config = _cfgVehicles >> _x;
+
+            // scopeCurator always has priority over scope, scope is only used if scopeCurator is not defined
+            if (getNumber (_config >> "scopeCurator") == 2 || {getNumber (_config >> "scope") == 2 && {!isNumber (_config >> "scopeCurator")}}) then {
+                private _side = getNumber (_config >> "side");
+
+                if (_side in [0, 1, 2, 3]) then {
+                    // Either editorCategory or faction can be used to set an object's category
+                    // Usually, faction is used for characters and vehicles and editorCategory is used for props
+                    // When both are present, editorCategory has priority and is used by Zeus
+                    private _factionConfig = if (isText (_config >> "editorCategory")) then {
+                        _cfgEditorCategories >> getText (_config >> "editorCategory")
+                    } else {
+                        _cfgFactionClasses >> getText (_config >> "faction")
+                    };
+
+                    _factions pushBackUnique [getText (_factionConfig >> "displayName"), configName _factionConfig, _side];
+                };
+            };
+        };
+    } forEach getArray (_x >> "units");
+} forEach configProperties [configFile >> "CfgPatches", "isClass _x"];
+
+// Group compositions do not necessarily use the same faction names as the object's they contain
+{
+    private _side = getNumber (_x >> "side");
+
+    if (_side in [0, 1, 2, 3]) then {
+        {
+            private _name = getText (_x >> "name");
+
+            // Add the faction if one with this name and side does not exist yet
+            if (_factions findIf {_x select 0 == _name && {_x select 2 == _side}} == -1) then {
+                private _faction = configName _x;
+
+                // Add "_groups" suffix to the faction class name if it already exists
+                // Happens when groups use the same faction class as objects but with a different display name
+                if (_factions findIf {_x select 1 == _faction} != -1) then {
+                    _faction = _faction + "_groups";
+                };
+
+                _factions pushBackUnique [_name, _faction, _side];
+            };
+        } forEach configProperties [_x, "isClass _x"];
+    };
+} forEach configProperties [configFile >> "CfgGroups", "isClass _x"];
+
+// Sort factions in ascending order by name
+_factions sort true;
+
+uiNamespace setVariable [QGVAR(factions), _factions];

--- a/addons/faction_filter/config.cpp
+++ b/addons/faction_filter/config.cpp
@@ -1,0 +1,19 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"zen_editor"};
+        author = ECSTRING(main,Author);
+        authors[] = {"mharis001", "Kex"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+PRELOAD_ADDONS;
+
+#include "CfgEventHandlers.hpp"

--- a/addons/faction_filter/script_component.hpp
+++ b/addons/faction_filter/script_component.hpp
@@ -1,0 +1,21 @@
+#define COMPONENT faction_filter
+#define COMPONENT_BEAUTIFIED Faction Filter
+#include "\x\zen\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_FACTION_FILTER
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_FACTION_FILTER
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_FACTION_FILTER
+#endif
+
+#include "\x\zen\addons\main\script_macros.hpp"
+
+#include "\x\zen\addons\common\defineResinclDesign.inc"
+
+#define FACTION_ID(side,name) format [QGVAR(%1:%2), side, name]

--- a/addons/faction_filter/stringtable.xml
+++ b/addons/faction_filter/stringtable.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="ZEN">
+    <Package name="Faction_Filter">
+        <Key ID="STR_ZEN_Faction_Filter_DisplayName">
+            <English>Zeus Enhanced - Faction Filter</English>
+        </Key>
+    </Package>
+</Project>

--- a/addons/faction_filter/stringtable.xml
+++ b/addons/faction_filter/stringtable.xml
@@ -3,7 +3,7 @@
     <Package name="Faction_Filter">
         <Key ID="STR_ZEN_Faction_Filter_DisplayName">
             <English>Zeus Enhanced - Faction Filter</English>
-            <French>Zeus Enhanced - Filtre de Fraction</French>
+            <French>Zeus Enhanced - Filtre des Fractions</French>
             <German>Zeus Enhanced - Fraktionsfilter</German>
         </Key>
     </Package>

--- a/addons/faction_filter/stringtable.xml
+++ b/addons/faction_filter/stringtable.xml
@@ -3,6 +3,8 @@
     <Package name="Faction_Filter">
         <Key ID="STR_ZEN_Faction_Filter_DisplayName">
             <English>Zeus Enhanced - Faction Filter</English>
+            <French>Zeus Enhanced - Filtre de Fraction</French>
+            <German>Zeus Enhanced - Fraktionsfilter</German>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Add `faction_filter` component
    - Adds settings to control which factions (by name) are available in the unit and group trees
    - Close #142 
- Fix invisible side buttons on initial load with empty trees
    - Simplify code for `modeChanged` and `sideChanged` events

Works well when tested with popular asset mods. Deals with the following object categorization trickiness (for Zeus):
- `side` of `CfgFactionClasses` doesn't determine under which side an object is sorted.
- `editorCategory` can also be used to categorize an object (although generally not used for characters and vehicles).
- group compositions can have a different faction display name than objects from the same faction.

 As a result, we don't use `CfgFactionClasses` directly and instead scan `CfgPatches` `units` arrays and `CfgGroups` to find factions.
