### PR TITLE
Clean up compositions randomize button code

### DIFF
--- a/addons/compositions/functions/fnc_buttonRandomize.sqf
+++ b/addons/compositions/functions/fnc_buttonRandomize.sqf
@@ -5,19 +5,22 @@
  *
  * Arguments:
  * 0: Button <CONTROL>
+ * 1: Toggle <BOOL> (defualt: true)
  *
  * Return Value:
  * None
  *
  * Example:
- * [] call zen_compositions_fnc_buttonRandomize
+ * [CONTROL] call zen_compositions_fnc_buttonRandomize
  *
  * Public: No
  */
 
-params ["_ctrlRandomize"];
+params ["_ctrlRandomize", ["_toggle", true]];
 
-GVAR(randomize) = !GVAR(randomize);
+if (_toggle) then {
+    GVAR(randomize) = !GVAR(randomize);
+};
 
 private _color = [[1, 1, 1, 0.25], [1, 1, 1, 1]] select GVAR(randomize);
 _ctrlRandomize ctrlSetTextColor _color;

--- a/addons/compositions/functions/fnc_initDisplayCurator.sqf
+++ b/addons/compositions/functions/fnc_initDisplayCurator.sqf
@@ -36,12 +36,7 @@
 
     // Set the initial state of the randomize button
     private _ctrlRandomize = _display displayCtrl IDC_PANEL_RANDOMIZE;
-
-    private _color = [[1, 1, 1, 0.25], [1, 1, 1, 1]] select GVAR(randomize);
-    _ctrlRandomize ctrlSetTextColor _color;
-
-    private _tooltip = [LSTRING(RandomizationOff), LSTRING(RandomizationOn)] select GVAR(randomize);
-    _ctrlRandomize ctrlSetTooltip localize _tooltip;
+    [_ctrlRandomize, false] call FUNC(buttonRandomize);
 
     // There are situations where the custom category is not shown in the tree
     // To workaround this, any needed tree additions are processed when tree items may change


### PR DESCRIPTION
**When merged this pull request will:**
- title, remove duplicate code for setting color and tooltip in `initDisplayCurator`