### PR TITLE
Fix remote control owner variable not being reset after disconnect

### DIFF
--- a/addons/remote_control/XEH_postInit.sqf
+++ b/addons/remote_control/XEH_postInit.sqf
@@ -1,5 +1,20 @@
 #include "script_component.hpp"
 
+if (isServer) then {
+    // Reset owner variable if a player disconnects while remote controlling a unit
+    addMissionEventHandler ["HandleDisconnect", {
+        params ["_unit"];
+
+        if (!isNull getAssignedCuratorLogic _unit) then {
+            {
+                if (_x getVariable [VAR_OWNER, objNull] == _unit) exitWith {
+                    _x setVariable [VAR_OWNER, nil, true];
+                };
+            } forEach allUnits;
+        };
+    }];
+};
+
 ["zen_curatorDisplayLoaded", {
     params ["_display"];
 


### PR DESCRIPTION
**When merged this pull request will:**
- title, owner variable was not reset if a player disconnected while remote controlling