### PR TITLE
Improve pylon turret functionality by using getAllPylonsInfo

### DIFF
--- a/addons/common/functions/fnc_exportMissionSQF.sqf
+++ b/addons/common/functions/fnc_exportMissionSQF.sqf
@@ -271,13 +271,11 @@ private _fnc_processVehicle = {
         _outputObjects pushBack ["{%1 addMagazineTurret _x} forEach %2;", _varName, _turretMagazines];
 
         {
-            private _pylonIndex = _forEachIndex + 1;
-            private _turretPath = [_vehicle, _forEachIndex] call FUNC(getPylonTurret);
-            private _ammoCount = _vehicle ammoOnPylon _pylonIndex;
+            _x params ["_pylonIndex", "", "_turretPath", "_magazine", "_ammoCount"];
 
-            _outputObjects pushBack ["%1 setPylonLoadOut [%2, %3, false, %4];", _varName, _pylonIndex, str _x, _turretPath];
+            _outputObjects pushBack ["%1 setPylonLoadOut [%2, %3, false, %4];", _varName, _pylonIndex, str _magazine, _turretPath];
             _outputObjects pushBack ["%1 setAmmoOnPylon [%2, %3];", _varName, _pylonIndex, _ammoCount];
-        } forEach _pylonMagazines;
+        } forEach getAllPylonsInfo _vehicle;
 
         {
             _x params ["_unit", "_role", "_cargoIndex", "_turretPath"];

--- a/addons/common/functions/fnc_getPylonTurret.sqf
+++ b/addons/common/functions/fnc_getPylonTurret.sqf
@@ -2,7 +2,6 @@
 /*
  * Author: mharis001
  * Returns the turret path that owns the given pylon.
- * Will return the config defined turret if the owner is ambiguous.
  *
  * Arguments:
  * 0: Vehicle <OBJECT>
@@ -19,32 +18,4 @@
 
 params ["_vehicle", "_pylonIndex"];
 
-// Get the pylon magazine and current ammo for the given pylon index
-private _pylonMagazine = getPylonMagazines _vehicle select _pylonIndex;
-private _pylonAmmo = _vehicle ammoOnPylon (_pylonIndex + 1);
-
-// Get turret paths for magazines of the same type and current ammo count
-private _turretPaths = [];
-
-{
-    _x params ["_magazine", "_turretPath", "_ammoCount"];
-
-    if (_magazine == _pylonMagazine && {_ammoCount == _pylonAmmo}) then {
-        // Pylons uses [] for driver turret instead of the normal [-1]
-        if (_turretPath isEqualTo [-1]) then {
-            _turretPath = [];
-        };
-
-        _turretPaths pushBackUnique _turretPath;
-    };
-} forEach magazinesAllTurrets _vehicle;
-
-// Exit with the matched turret path if only one was found
-if (count _turretPaths == 1) exitWith {
-    _turretPaths select 0
-};
-
-// More than one turret path or none were found, situation is ambiguous
-// Return the config defined turret path for this pylon
-private _pylonConfig = configOf _vehicle >> "Components" >> "TransportPylonsComponent" >> "Pylons";
-getArray (configProperties [_pylonConfig, "isClass _x"] select _pylonIndex >> "turret")
+getAllPylonsInfo _vehicle param [_pylonIndex, []] param [2, [-1]]

--- a/addons/pylons/functions/fnc_configure.sqf
+++ b/addons/pylons/functions/fnc_configure.sqf
@@ -54,6 +54,11 @@ private _controls = [];
     private _mirroredIndex = getNumber (_x >> "mirroredMissilePos") - 1;
     private _defaultTurretPath = getArray (_x >> "turret");
 
+    // Pylon config can use [] as the driver turret path
+    if (_defaultTurretPath isEqualTo []) then {
+        _defaultTurretPath = [-1];
+    };
+
     private _ctrlCombo = _display ctrlCreate ["ctrlCombo", -1];
     _ctrlCombo ctrlSetPosition [_posX, _posY, GRID_W(82/3), GRID_H(5)];
     _ctrlCombo ctrlCommit 0;

--- a/addons/pylons/functions/fnc_handleConfirm.sqf
+++ b/addons/pylons/functions/fnc_handleConfirm.sqf
@@ -34,11 +34,11 @@ private _pylonLoadout = [];
     _x params ["_ctrlCombo", "_ctrlTurret"];
 
     private _magazine = _ctrlCombo lbData lbCurSel _ctrlCombo;
-    private _turretPath = _ctrlTurret getVariable [QGVAR(turretPath), []];
+    private _turretPath = _ctrlTurret getVariable [QGVAR(turretPath), [-1]];
 
     private _pylonWeapon = configName (_cfgWeapons >> getText (_cfgMagazines >> _magazine >> "pylonWeapon"));
 
-    if (_turretPath isEqualTo []) then {
+    if (_turretPath isEqualTo [-1]) then {
         _driverWeapons pushBackUnique _pylonWeapon;
     } else {
         _gunnerWeapons pushBackUnique _pylonWeapon;

--- a/addons/pylons/functions/fnc_handleMagazineSelect.sqf
+++ b/addons/pylons/functions/fnc_handleMagazineSelect.sqf
@@ -40,7 +40,7 @@ if (cbChecked (_display displayCtrl IDC_MIRROR)) then {
     {
         _x params ["_ctrlComboMirrored", "", "_mirroredIndex"];
 
-        if (_mirroredIndex == _pylonIndex) then {
+        if (_mirroredIndex == _pylonIndex) exitWith {
             _ctrlComboMirrored lbSetCurSel _selectedIndex;
         };
     } forEach (_display getVariable QGVAR(controls));

--- a/addons/pylons/functions/fnc_handleTurretButton.sqf
+++ b/addons/pylons/functions/fnc_handleTurretButton.sqf
@@ -22,7 +22,7 @@ private _turretPath = _ctrlTurret getVariable QGVAR(turretPath);
 
 // Toggle between driver and gunner turret if required
 if (_toggle) then {
-    _turretPath = [[], [0]] select (_turretPath isEqualTo []);
+    _turretPath = [[-1], [0]] select (_turretPath isEqualTo [-1]);
     _ctrlTurret setVariable [QGVAR(turretPath), _turretPath];
 
     private _display = ctrlParent _ctrlTurret;
@@ -43,7 +43,7 @@ if (_toggle) then {
 };
 
 // Update the button's icon and tooltip
-if (_turretPath isEqualTo []) then {
+if (_turretPath isEqualTo [-1]) then {
     _ctrlTurret ctrlSetText ICON_DRIVER;
     _ctrlTurret ctrlSetTooltip localize "STR_Driver";
 } else {


### PR DESCRIPTION
**When merged this pull request will:**
- Improve `getPylonTurret` common function by using `getAllPylonsInfo` command (2.02)
    - `setPylonLoadout` now supports `[-1]` as the driver turret
- Use `getAllPylonsInfo` for export mission SQF
