### PR TITLE
Sentence case comment linter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,8 @@ jobs:
       run: python3 tools/stringtable_validator.py
     - name: Validate Return Types
       run: python3 tools/return_checker.py
+    - name: Validate Comments
+      run: python3 tools/comment_linter.py
     - name: Check for BOM
       uses: arma-actions/bom-check@master
   build:

--- a/docs/development/coding_guidelines.md
+++ b/docs/development/coding_guidelines.md
@@ -307,9 +307,9 @@ All inline comments must start with a uppercase letter.
 Example:
 
 ```sqf
-//// Comment   // < incorrect
-// Comment     // < correct
-/* Comment */  // < correct
+//// Comment   // < Incorrect
+// Comment     // < Correct
+/* Comment */  // < Correct
 ```
 
 ### 5.4 Comments In Code
@@ -321,7 +321,7 @@ Comments within the code shall be used when they are describing a complex and cr
 **Good:**
 
 ```sqf
-// find the object with the most blood loss
+// Find the object with the most blood loss
 _highestObj = objNull;
 _highestLoss = -1;
 {
@@ -476,7 +476,7 @@ Declarations should be at the smallest feasible scope.
 
 ```sqf
 if (call FUNC(myCondition)) then {
-   private _areAllAboveTen = true; // <- smallest feasable scope
+   private _areAllAboveTen = true; // <- Smallest feasable scope
 
    {
       if (_x >= 10) then {
@@ -493,7 +493,7 @@ if (call FUNC(myCondition)) then {
 **Bad:**
 
 ```sqf
-private _areAllAboveTen = true; // <- this is bad, because it can be initialized in the if statement
+private _areAllAboveTen = true; // <- This is bad, because it can be initialized in the if statement
 if (call FUNC(myCondition)) then {
    {
       if (_x >= 10) then {
@@ -514,7 +514,7 @@ Private variables will not be introduced until they can be initialized with mean
 **Good:**
 
 ```sqf
-private _myVariable = 0; // good because the value will be used
+private _myVariable = 0; // Good because the value will be used
 {
     _x params ["_value", "_amount"];
     if (_value > 0) then {
@@ -762,7 +762,7 @@ while {_original < _weaponThreshold} do {
 
 ```sqf
 while {true} do {
-    // anything
+    // Anything
 };
 ```
 

--- a/docs/development/coding_guidelines.md
+++ b/docs/development/coding_guidelines.md
@@ -302,6 +302,8 @@ call {
 
 Inline comments should use `//`. Usage of `/* */` is allowed for larger comment blocks.
 
+All inline comments must start with a uppercase letter.
+
 Example:
 
 ```sqf

--- a/tools/comment_linter.py
+++ b/tools/comment_linter.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+# COMMENT VALIDATOR
+# Author: CreepPork
+# ---------------------
+# Verifies all *.cpp, *.hpp and *.sqf files in the project.
+# Checks if there are comments that start with a lowercase letter (all other symbols are ignored).
+
+import fnmatch
+import os
+import re
+import sys
+
+
+def get_files():
+    # Allow running from root directory and tools directory
+    root_dir = '..'
+    if os.path.exists('addons'):
+        root_dir = '.'
+
+    code_files = []
+
+    for root, _, files in os.walk(root_dir):
+        for file in files:
+            if file.lower().endswith(('.cpp', '.hpp', '.sqf')):
+                code_files.append(os.path.join(root, file))
+
+    code_files.sort()
+
+    return code_files
+
+
+def lint_file_for_comments(filepath: str):
+    invalid_comments = []
+
+    with open(filepath, 'r') as file_contents:
+        for (line_number, line) in enumerate(file_contents):
+            contents = line.strip()
+
+            # If regex matched a comment
+            if re.search('^((?!http).)*//(\s|)*((?!http.*))[a-z]', contents):
+                # Lines start with 1, but as indexes start with 0, so we have to increment
+                invalid_comments.append((line_number + 1, contents))
+
+    return invalid_comments
+
+
+def main():
+    print('Validating code comments')
+    print('------------------------')
+
+    exit_code = 0
+    validated_files = 0
+    errors_found = 0
+
+    files = get_files()
+
+    for filepath in files:
+        comments = lint_file_for_comments(filepath)
+
+        validated_files += 1
+
+        # Skip files without errors
+        if len(comments) == 0:
+            continue
+
+        errors_found += 1
+
+        for (line_number, comment) in comments:
+            if exit_code == 0:
+                exit_code = 1
+
+            print(f'ERROR: Comment must start with an uppercase letter.')
+            print(f'       {filepath}:{line_number}')
+            print(f'       {comment}')
+            print()
+
+    print(f'Checked {validated_files} files, found errors in {errors_found}.')
+    print((
+        'Comment validation PASSED' if exit_code == 0
+        else 'Comment validation FAILED'
+    ))
+
+    return exit_code
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
**When merged this pull request will:**
- Adds a Python linter that will lint all comments in `*.sqf`, `*.cpp` and `*.hpp` files (only `//` comments are checked)
- It will check if comments start with a lowercase letter (introduces various inconsistencies in the code)
- Ignores comments that contain various URLs (`http`/`https`)
- Update the coding guidelines to enforce that all comments start with a uppercase letter
- Fix existing inconsistencies in the code base regarding comments

For the future (will not be included in this PR):
- Add a feature that will also check if there is a space or not between the start of the comment and the comment text
