### PR TITLE
Reload Zeus Interface Keybind

### DIFF
--- a/addons/editor/initKeybinds.sqf
+++ b/addons/editor/initKeybinds.sqf
@@ -104,7 +104,7 @@
 // Hack fix for the Zeus lockup bug, will reopen Zeus interface.
 [ELSTRING(main,DisplayName), QGVAR(reloadDisplay), [LSTRING(ReloadDisplay), LSTRING(ReloadDisplay_Description)], {
     if (!isNull curatorCamera && {!GETMVAR(RscDisplayCurator_search,false)}) then {
-        findDisplay 312 closeDisplay 2;
+        findDisplay IDD_RSCDISPLAYCURATOR closeDisplay IDC_CANCEL;
 
         {openCuratorInterface} call CBA_fnc_execNextFrame;
 

--- a/addons/editor/initKeybinds.sqf
+++ b/addons/editor/initKeybinds.sqf
@@ -100,3 +100,14 @@
         };
     };
 }, {}, [0, [false, false, false]]] call CBA_fnc_addKeybind; // Default: Unbound
+
+// Hack fix for the Zeus lockup bug, will reopen Zeus interface.
+[ELSTRING(main,DisplayName), QGVAR(reloadDisplay), [LSTRING(ReloadDisplay), LSTRING(ReloadDisplay_Description)], {
+    if (!isNull curatorCamera && {!GETMVAR(RscDisplayCurator_search,false)}) then {
+        findDisplay 312 closeDisplay 2;
+
+        {openCuratorInterface} call CBA_fnc_execNextFrame;
+
+        true //handled
+    };
+}, {}, [DIK_R, [true, true, false]]] call CBA_fnc_addKeybind; // Default: CTRL + SHIFT + R

--- a/addons/editor/stringtable.xml
+++ b/addons/editor/stringtable.xml
@@ -222,5 +222,11 @@
             <Japanese>全編集可アイコンの視認性を切り替えます。一時的な処理軽減や整理に使用できます。</Japanese>
             <Polish>Przełącza widoczność wszsytkich ustawionych ikon, przydatne by tymczasowo zmniejszyć lag, bądź niepotrzebne zaśmiecenie ekranu gdy znajduje się na nim dużo ikon.</Polish>
         </Key>
+        <Key ID="STR_ZEN_Editor_ReloadDisplay">
+            <English>Reload Display</English>
+        </Key>
+        <Key ID="STR_ZEN_Editor_ReloadDisplay_Description">
+            <English>Reloads the Display to fix the UI lockup bug.</English>
+        </Key>
     </Package>
 </Project>

--- a/addons/editor/stringtable.xml
+++ b/addons/editor/stringtable.xml
@@ -226,7 +226,7 @@
             <English>Reload Display</English>
         </Key>
         <Key ID="STR_ZEN_Editor_ReloadDisplay_Description">
-            <English>Reloads the Display to fix the UI lockup bug.</English>
+            <English>Reloads the Zeus interface (can be used to fix various lockup issues).</English>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Add a keybind to reload the Zeus interface when needed.
- Hack for #152 but not a fix