### PR TITLE
Misc cleanup for reload display keybind

### DIFF
--- a/addons/editor/initKeybinds.sqf
+++ b/addons/editor/initKeybinds.sqf
@@ -101,7 +101,6 @@
     };
 }, {}, [0, [false, false, false]]] call CBA_fnc_addKeybind; // Default: Unbound
 
-// Hack fix for the Zeus lockup bug, will reopen Zeus interface.
 [ELSTRING(main,DisplayName), QGVAR(reloadDisplay), [LSTRING(ReloadDisplay), LSTRING(ReloadDisplay_Description)], {
     if (!isNull curatorCamera && {!GETMVAR(RscDisplayCurator_search,false)}) then {
         findDisplay IDD_RSCDISPLAYCURATOR closeDisplay IDC_CANCEL;

--- a/addons/editor/stringtable.xml
+++ b/addons/editor/stringtable.xml
@@ -226,7 +226,7 @@
             <English>Reload Display</English>
         </Key>
         <Key ID="STR_ZEN_Editor_ReloadDisplay_Description">
-            <English>Reloads the Zeus interface (can be used to fix various lockup issues).</English>
+            <English>Reloads the Zeus interface. Can be used to fix lockup issues.</English>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Very minor cleanup after #542 
- Not really a hack. Standard way to reload Zeus display