### PR TITLE
Faction Filter - Use hash map and ensure strings in units array

### DIFF
--- a/addons/faction_filter/XEH_postInit.sqf
+++ b/addons/faction_filter/XEH_postInit.sqf
@@ -37,7 +37,7 @@
                 private _name = _ctrlTree tvText _path;
 
                 // Get the setting variable name that corresponds to this faction's name and side
-                private _varName = GVAR(map) getVariable [FACTION_ID(_forEachIndex,_name), ""];
+                private _varName = GVAR(map) getOrDefault [[_forEachIndex, _name], ""];
 
                 if !(missionNamespace getVariable [_varName, true]) then {
                     _ctrlTree tvDelete _path;

--- a/addons/faction_filter/XEH_preInit.sqf
+++ b/addons/faction_filter/XEH_preInit.sqf
@@ -5,13 +5,13 @@ ADDON = false;
 // Create trees do not provide the faction class name that a given node represents
 // Only the faction's name and side can be obtained from the tree
 // This namespace maps a faction's name and side to its corresponding setting variable name
-GVAR(map) = [] call CBA_fnc_createNamespace;
+GVAR(map) = createHashMap;
 
 {
     _x params ["_name", "_faction", "_side"];
 
     private _varName = format [QGVAR(%1_%2), _side, _faction];
-    GVAR(map) setVariable [FACTION_ID(_side,_name), _varName];
+    GVAR(map) set [[_side, _name], _varName];
 
     private _sideName = ["str_east", "str_west", "str_guerrila", "str_civilian"] select _side;
     [_varName, "CHECKBOX", _name, [LSTRING(DisplayName), _sideName], true, false] call CBA_fnc_addSetting;

--- a/addons/faction_filter/XEH_preStart.sqf
+++ b/addons/faction_filter/XEH_preStart.sqf
@@ -9,7 +9,8 @@ private _cfgEditorCategories = configFile >> "CfgEditorCategories";
 {
     {
         // Classes that do not inherit from AllVehicles have thier side ignored and are considered props (Zeus also ignores animals)
-        if (_x isKindOf "AllVehicles" && {!(_x isKindOf "Animal")}) then {
+        // The isEqualType check is here because some mods are incorrectly configured and have numbers in the CfgPatches units array
+        if (_x isEqualType "" && {_x isKindOf "AllVehicles"} && {!(_x isKindOf "Animal")}) then {
             private _config = _cfgVehicles >> _x;
 
             // scopeCurator always has priority over scope, scope is only used if scopeCurator is not defined

--- a/addons/faction_filter/script_component.hpp
+++ b/addons/faction_filter/script_component.hpp
@@ -17,5 +17,3 @@
 #include "\x\zen\addons\main\script_macros.hpp"
 
 #include "\x\zen\addons\common\defineResinclDesign.inc"
-
-#define FACTION_ID(side,name) format [QGVAR(%1:%2), side, name]


### PR DESCRIPTION
**When merged this pull request will:**
- Use hash map instead of CBA namespace for faction side and name to setting mapping
- Only consider strings in `CfgPatches` `units` arrays since some mods are incorrectly configured
    - Reference #557 
