### PR TITLE
add: _valueInfo evaluation

### DIFF
--- a/addons/attributes/functions/fnc_gui_combo.sqf
+++ b/addons/attributes/functions/fnc_gui_combo.sqf
@@ -20,7 +20,15 @@
  */
 
 params ["_controlsGroup", "_defaultValue", "_valueInfo"];
+
+//Value Info Eval
+if(typeName _valueInfo == typeName {}) then {
+    _valueInfo = call _valueInfo;
+    if(typeName _valueInfo != typeName []) then { _valueInfo = [] };
+};
+
 _valueInfo params [["_entries", [], [[]]]];
+
 
 private _ctrlCombo = _controlsGroup controlsGroupCtrl IDC_ATTRIBUTE_COMBO;
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add _valueInfo evaluation only if the variable is a codeblock (typeName = "CODE")
- Evaluate _valueInfo to be able to create combo attributes with dynamic values
- Fallback to previous behaviour if _valueInfo is not a codeblock

PR for #576