### PR TITLE
Add Cover Map module

### DIFF
--- a/addons/area_markers/functions/fnc_configure.sqf
+++ b/addons/area_markers/functions/fnc_configure.sqf
@@ -36,7 +36,7 @@ markerSize _marker params ["_sizeA", "_sizeB"];
 
 private _ctrlRotationSlider = _ctrlConfigure controlsGroupCtrl IDC_CONFIGURE_ROTATION_SLIDER;
 private _ctrlRotationEdit   = _ctrlConfigure controlsGroupCtrl IDC_CONFIGURE_ROTATION_EDIT;
-[_ctrlRotationSlider, _ctrlRotationEdit, 0, 360, markerDir _marker, 15, {format ["%1%2", round _this, toString [ASCII_DEGREE]]}] call EFUNC(common,initSliderEdit);
+[_ctrlRotationSlider, _ctrlRotationEdit, 0, 360, markerDir _marker, 15, EFUNC(common,formatDegrees)] call EFUNC(common,initSliderEdit);
 
 private _ctrlShape = _ctrlConfigure controlsGroupCtrl IDC_CONFIGURE_SHAPE;
 _ctrlShape lbSetCurSel (["RECTANGLE", "ELLIPSE"] find markerShape _marker);

--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -13,6 +13,7 @@ PREP(exportMissionSQF);
 PREP(exportText);
 PREP(fireArtillery);
 PREP(fireVLS);
+PREP(formatDegrees);
 PREP(getActiveTree);
 PREP(getAllTurrets);
 PREP(getArtilleryETA);

--- a/addons/common/functions/fnc_formatDegrees.sqf
+++ b/addons/common/functions/fnc_formatDegrees.sqf
@@ -1,0 +1,20 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Formats the given number into a string with the degree symbol.
+ *
+ * Arguments:
+ * 0: Degrees <NUMBER>
+ *
+ * Return Value:
+ * Formatted String <STRING>
+ *
+ * Example:
+ * [90] call zen_common_fnc_formatDegrees
+ *
+ * Public: No
+ */
+
+params [["_degrees", 0, [0]]];
+
+format ["%1%2", round _degrees, toString [ASCII_DEGREE]]

--- a/addons/cover_map/$PBOPREFIX$
+++ b/addons/cover_map/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\zen\addons\cover_map

--- a/addons/cover_map/CfgEventHandlers.hpp
+++ b/addons/cover_map/CfgEventHandlers.hpp
@@ -1,0 +1,17 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+    };
+};
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
+    };
+};

--- a/addons/cover_map/CfgVehicles.hpp
+++ b/addons/cover_map/CfgVehicles.hpp
@@ -1,8 +1,7 @@
 class CfgVehicles {
     class EGVAR(modules,moduleBase);
     class GVAR(module): EGVAR(modules,moduleBase) {
-        displayName = CSTRING(CreateAreaMarker);
-        function = QFUNC(module);
-        icon = ICON_MARKERS;
+        displayName = "$STR_A3_CfgVehicles_ModuleCoverMap_F";
+        curatorInfoType = QGVAR(display);
     };
 };

--- a/addons/cover_map/XEH_PREP.hpp
+++ b/addons/cover_map/XEH_PREP.hpp
@@ -1,0 +1,10 @@
+PREP(create);
+PREP(handleConfirm);
+PREP(handleDelete);
+PREP(handleDraw);
+PREP(handleLoad);
+PREP(handleMouseButtonDown);
+PREP(handleMouseButtonUp);
+PREP(handleMouseMoving);
+PREP(handleRotationChanged);
+PREP(remove);

--- a/addons/cover_map/XEH_postInit.sqf
+++ b/addons/cover_map/XEH_postInit.sqf
@@ -1,0 +1,6 @@
+#include "script_component.hpp"
+
+if (isServer) then {
+    [QGVAR(create), LINKFUNC(create)] call CBA_fnc_addEventHandler;
+    [QGVAR(remove), LINKFUNC(remove)] call CBA_fnc_addEventHandler;
+};

--- a/addons/cover_map/XEH_preInit.sqf
+++ b/addons/cover_map/XEH_preInit.sqf
@@ -1,0 +1,9 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+PREP_RECOMPILE_START;
+#include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
+
+ADDON = true;

--- a/addons/cover_map/XEH_preStart.sqf
+++ b/addons/cover_map/XEH_preStart.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+#include "XEH_PREP.hpp"

--- a/addons/cover_map/config.cpp
+++ b/addons/cover_map/config.cpp
@@ -1,0 +1,23 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {
+            QGVAR(module)
+        };
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"zen_modules"};
+        author = ECSTRING(main,Author);
+        authors[] = {"mharis001"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+PRELOAD_ADDONS;
+
+#include "CfgEventHandlers.hpp"
+#include "CfgVehicles.hpp"
+#include "gui.hpp"

--- a/addons/cover_map/functions/fnc_create.sqf
+++ b/addons/cover_map/functions/fnc_create.sqf
@@ -1,0 +1,78 @@
+#include "script_component.hpp"
+/*
+ * Author: Bohemia Interactive, mharis001
+ * Creates the cover map effect.
+ *
+ * Arguments:
+ * 0: Center <ARRAY>
+ * 1: Size <ARRAY>
+ * 3: Rotation <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [[0, 0], [1000, 1000], 0] call zen_cover_map_fnc_create
+ *
+ * Public: No
+ */
+
+#define SIZE_OUT 100000
+
+params [
+    ["_center", [0, 0], [[]], [2, 3]],
+    ["_size", [0, 0], [[]], 2],
+    ["_angle", 0, [0]]
+];
+
+_center params [
+    ["_centerX", 0, [0]],
+    ["_centerY", 0, [0]]
+];
+
+_size params [
+    ["_sizeX", 0, [0]],
+    ["_sizeY", 0, [0]]
+];
+
+// Remove an already existent cover map effect first
+[] call FUNC(remove);
+
+// Create cover and corner markers
+{
+    private _direction = _angle + _x;
+    private _sizeA = [_sizeX, _sizeY] select abs cos _x;
+    private _sizeB = [_sizeX, _sizeY] select abs sin _x;
+    private _sizeMarker = [_sizeB, SIZE_OUT] select abs sin _x;
+
+    private _coverPos = [
+        _centerX + sin _direction * SIZE_OUT,
+        _centerY + cos _direction * SIZE_OUT
+    ];
+
+    private _markerCover = createMarker [format [QGVAR(cover_%1), _x], _coverPos];
+    _markerCover setMarkerShape "RECTANGLE";
+    _markerCover setMarkerBrush "Solid";
+    _markerCover setMarkerColor "ColorBlack";
+    _markerCover setMarkerSize [_sizeMarker, SIZE_OUT - _sizeA];
+    _markerCover setMarkerDir _direction;
+
+    private _dotPos = [
+        _centerX + sin _direction * _sizeA + sin (_direction + 90) * _sizeB,
+        _centerY + cos _direction * _sizeA + cos (_direction + 90) * _sizeB
+    ];
+
+    private _markerDot = createMarker [format [QGVAR(dot_%1), _x], _dotPos];
+    _markerDot setMarkerColor "ColorBlack";
+    _markerDot setMarkerType "mil_box_noShadow";
+    _markerDot setMarkerSize [0.75, 0.75];
+    _markerDot setMarkerDir _direction;
+} forEach [0, 90, 180, 270];
+
+// Create border marker
+private _markerBorder = createMarker [QGVAR(border), [_centerX, _centerY]];
+_markerBorder setMarkerShape "RECTANGLE";
+_markerBorder setMarkerBrush "Border";
+_markerBorder setMarkerColor "ColorBlack";
+_markerBorder setMarkerSize [_sizeX, _sizeY];
+_markerBorder setMarkerDir _angle;

--- a/addons/cover_map/functions/fnc_handleConfirm.sqf
+++ b/addons/cover_map/functions/fnc_handleConfirm.sqf
@@ -1,0 +1,28 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles pressing the OK button.
+ *
+ * Arguments:
+ * 0: Button <CONTROL>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [CONTROL] call zen_cover_map_fnc_handleConfirm
+ *
+ * Public: No
+ */
+
+params ["_ctrlButtonOK"];
+
+private _display = ctrlParent _ctrlButtonOK;
+private _ctrlMap = _display displayCtrl IDC_MAP;
+private _area = _ctrlMap getVariable QGVAR(area);
+
+if (isNil "_area") then {
+    [QGVAR(remove)] call CBA_fnc_serverEvent;
+} else {
+    [QGVAR(create), _area] call CBA_fnc_serverEvent;
+};

--- a/addons/cover_map/functions/fnc_handleDelete.sqf
+++ b/addons/cover_map/functions/fnc_handleDelete.sqf
@@ -1,0 +1,22 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles pressing the delete button.
+ *
+ * Arguments:
+ * 0: Button <CONTROL>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [CONTROL] call zen_cover_map_fnc_handleDelete
+ *
+ * Public: No
+ */
+
+params ["_ctrlDelete"];
+
+private _display = ctrlParent _ctrlDelete;
+private _ctrlMap = _display displayCtrl IDC_MAP;
+_ctrlMap setVariable [QGVAR(area), nil];

--- a/addons/cover_map/functions/fnc_handleDraw.sqf
+++ b/addons/cover_map/functions/fnc_handleDraw.sqf
@@ -1,0 +1,34 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles drawing the current area on the map.
+ *
+ * Arguments:
+ * 0: Map <CONTROL>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [CONTROL] call zen_cover_map_fnc_handleDraw
+ *
+ * Public: No
+ */
+
+params ["_ctrlMap"];
+
+private _area = _ctrlMap getVariable QGVAR(area);
+private _areaExists = !isNil "_area";
+
+// Draw the current area if it exists
+if (_areaExists) then {
+    _area params ["_center", "_size", "_angle"];
+    _size params ["_sizeX", "_sizeY"];
+
+    _ctrlMap drawRectangle [_center, _sizeX, _sizeY, _angle, [1, 1, 1, 1], "#(rgb,8,8,3)color(1,0,0,0.25)"];
+};
+
+// Enable the delete button if an area exists
+private _display = ctrlParent _ctrlMap;
+private _ctrlDelete = _display displayCtrl IDC_DELETE;
+_ctrlDelete ctrlEnable _areaExists;

--- a/addons/cover_map/functions/fnc_handleLoad.sqf
+++ b/addons/cover_map/functions/fnc_handleLoad.sqf
@@ -1,0 +1,71 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles initializing the "Cover Map" module display.
+ *
+ * Arguments:
+ * 0: Display <DISPLAY>
+ * 1: Logic <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [DISPLAY, LOGIC] call zen_cover_map_fnc_handleLoad
+ *
+ * Public: No
+ */
+
+params ["_display", "_logic"];
+
+deleteVehicle _logic;
+
+// Reposition the content controls group to make space for the map
+private _ctrlContent = _display displayCtrl IDC_CONTENT;
+ctrlPosition _ctrlContent params ["_contentX", "_contentY", "_contentW", "_contentH"];
+
+_ctrlContent ctrlSetPositionY (_contentY + _contentH - POS_H(1));
+_ctrlContent ctrlSetPositionH POS_H(1);
+_ctrlContent ctrlCommit 0;
+
+// Create the area label
+private _ctrlLabel = _display ctrlCreate [QEGVAR(common,RscLabel), -1];
+_ctrlLabel ctrlSetText localize "STR_A3_CfgVehicles_LocationArea_F_0";
+_ctrlLabel ctrlSetTooltip localize LSTRING(Area_Tooltip);
+_ctrlLabel ctrlSetPosition [_contentX, _contentY, _contentW, POS_H(1)];
+_ctrlLabel ctrlCommit 0;
+
+// Create the delete area button
+private _ctrlDelete = _display ctrlCreate ["ctrlButtonPicture", IDC_DELETE];
+_ctrlDelete ctrlSetText "\a3\3den\data\cfg3den\history\deleteitems_ca.paa";
+_ctrlDelete ctrlSetPosition [_contentX + _contentW - POS_W(1), _contentY, POS_W(1), POS_H(1)];
+_ctrlDelete ctrlCommit 0;
+
+_ctrlDelete ctrlAddEventHandler ["ButtonClick", {call FUNC(handleDelete)}];
+
+// Create the map
+private _ctrlMap = _display ctrlCreate [QGVAR(RscMap), IDC_MAP];
+_ctrlMap ctrlSetPosition [_contentX, _contentY + POS_H(1), _contentW, POS_H(20)];
+_ctrlMap ctrlCommit 0;
+
+_ctrlMap ctrlAddEventHandler ["MouseButtonDown", {call FUNC(handleMouseButtonDown)}];
+_ctrlMap ctrlAddEventHandler ["MouseButtonUp", {call FUNC(handleMouseButtonUp)}];
+_ctrlMap ctrlAddEventHandler ["MouseMoving", {call FUNC(handleMouseMoving)}];
+_ctrlMap ctrlAddEventHandler ["Draw", {call FUNC(handleDraw)}];
+
+// If a cover map effect already exists, use it as the default area
+private _angle = 0;
+
+if (markerShape QGVAR(border) != "") then {
+    _angle = markerDir QGVAR(border);
+    _ctrlMap setVariable [QGVAR(area), [markerPos QGVAR(border), markerSize QGVAR(border), _angle]];
+};
+
+// Initialize the rotation slider and edit box
+private _ctrlSlider = _display displayCtrl IDC_ROTATION_SLIDER;
+private _ctrlEdit = _display displayCtrl IDC_ROTATION_EDIT;
+[_ctrlSlider, _ctrlEdit, 0, 360, _angle, 15, EFUNC(common,formatDegrees), false, FUNC(handleRotationChanged)] call EFUNC(common,initSliderEdit);
+
+// Confirm changes when the OK button is clicked
+private _ctrlButtonOK = _display displayCtrl IDC_OK;
+_ctrlButtonOK ctrlAddEventHandler ["ButtonClick", {call FUNC(handleConfirm)}];

--- a/addons/cover_map/functions/fnc_handleMouseButtonDown.sqf
+++ b/addons/cover_map/functions/fnc_handleMouseButtonDown.sqf
@@ -1,0 +1,43 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles pressing a mouse button on the map.
+ *
+ * Arguments:
+ * 0: Map <CONTROL>
+ * 1: Button <NUMBER>
+ * 2: X Position <NUMBER>
+ * 3: Y Position <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [CONTROL, 0, 0.5, 0.5] call zen_cover_map_fnc_handleMouseButtonDown
+ *
+ * Public: No
+ */
+
+params ["_ctrlMap", "_button", "_posX", "_posY"];
+
+if (_button == 0) then {
+    private _position = _ctrlMap ctrlMapScreenToWorld [_posX, _posY];
+    private _area = _ctrlMap getVariable QGVAR(area);
+
+    // If the area does not exist, start creating a new one
+    if (isNil "_area") then {
+        _ctrlMap setVariable [QGVAR(corner), _position];
+    } else {
+        _area params ["_center", "_size", "_angle"];
+        _size params ["_sizeX", "_sizeY"];
+
+        // If the clicked position is in the area, start moving it
+        // Otherwise, start creating a new one
+        if (_position inArea [_center, _sizeX, _sizeY, _angle, true, -1]) then {
+            private _offset = _center vectorDiff _position;
+            _ctrlMap setVariable [QGVAR(offset), _offset];
+        } else {
+            _ctrlMap setVariable [QGVAR(corner), _position];
+        };
+    };
+};

--- a/addons/cover_map/functions/fnc_handleMouseButtonUp.sqf
+++ b/addons/cover_map/functions/fnc_handleMouseButtonUp.sqf
@@ -1,0 +1,33 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles releasing a mouse button on the map.
+ *
+ * Arguments:
+ * 0: Map <CONTROL>
+ * 1: Button <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [CONTROL, 0] call zen_cover_map_fnc_handleMouseButtonUp
+ *
+ * Public: No
+ */
+
+params ["_ctrlMap", "_button"];
+
+if (_button == 0) then {
+    // Reset create and move area tracking variables
+    _ctrlMap setVariable [QGVAR(offset), nil];
+    _ctrlMap setVariable [QGVAR(corner), nil];
+
+    // Update the area's angle to reflect the current rotation
+    // Needed to apply rotation to newly created area
+    private _display = ctrlParent _ctrlMap;
+    private _ctrlSlider = _display displayCtrl IDC_ROTATION_SLIDER;
+
+    private _area = _ctrlMap getVariable QGVAR(area);
+    _area set [2, sliderPosition _ctrlSlider];
+};

--- a/addons/cover_map/functions/fnc_handleMouseMoving.sqf
+++ b/addons/cover_map/functions/fnc_handleMouseMoving.sqf
@@ -1,0 +1,47 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles moving the mouse on the map.
+ *
+ * Arguments:
+ * 0: Map <CONTROL>
+ * 1: X Position <NUMBER>
+ * 2: Y Position <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [CONTROL, 0.5, 0.5] call zen_cover_map_fnc_handleMouseMoving
+ *
+ * Public: No
+ */
+
+params ["_ctrlMap", "_posX", "_posY"];
+
+private _position = _ctrlMap ctrlMapScreenToWorld [_posX, _posY];
+
+// Handle moving the area if the move offset is set
+private _offset = _ctrlMap getVariable QGVAR(offset);
+
+if (!isNil "_offset") exitWith {
+    // Update the center of the area based on the current position
+    private _area = _ctrlMap getVariable QGVAR(area);
+    _area set [0, _position vectorAdd _offset];
+};
+
+// Handle creating a new area if the anchoring corner is set
+private _corner = _ctrlMap getVariable QGVAR(corner);
+
+if (!isNil "_corner") exitWith {
+    // Calculate the area's center by getting the midpoint of the diagonal end points
+    private _center = _corner vectorAdd _position vectorMultiply 0.5;
+
+    // Calculate the area's size by getting the distance between the two end points
+    // Selecting first two elements since 2D vector commands return 3D vector with z = 0
+    private _size = _corner vectorDiff _position apply {abs _x * 0.5} select [0, 2];
+
+    // Store the current area, use angle of 0 while the area is being created
+    // The selected rotation will be applied after the area is confirmed (release mouse button)
+    _ctrlMap setVariable [QGVAR(area), [_center, _size, 0]];
+};

--- a/addons/cover_map/functions/fnc_handleRotationChanged.sqf
+++ b/addons/cover_map/functions/fnc_handleRotationChanged.sqf
@@ -1,0 +1,30 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles changing the area's rotation using the slider or edit box.
+ *
+ * Arguments:
+ * 0: Slider <CONTROL>
+ * 1: Edit (not used) <CONTROL>
+ * 2: Value <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [CONTROL, CONTROL, 90] call zen_cover_map_fnc_handleRotationChanged
+ *
+ * Public: No
+ */
+
+params ["_ctrlSlider", "", "_angle"];
+
+private _display = ctrlParent _ctrlSlider;
+private _ctrlMap = _display displayCtrl IDC_MAP;
+
+// Update the current area's angle if it exists
+private _area = _ctrlMap getVariable QGVAR(area);
+
+if (!isNil "_area") then {
+    _area set [2, _angle];
+};

--- a/addons/cover_map/functions/fnc_remove.sqf
+++ b/addons/cover_map/functions/fnc_remove.sqf
@@ -1,0 +1,23 @@
+#include "script_component.hpp"
+/*
+ * Author: Bohemia Interactive, mharis001
+ * Removes the cover map effect.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call zen_cover_map_fnc_remove
+ *
+ * Public: No
+ */
+
+// Delete all markers created by the cover map effect
+{
+    if (QUOTE(ADDON) in _x) then {
+        deleteMarker _x;
+    };
+} forEach allMapMarkers;

--- a/addons/cover_map/functions/script_component.hpp
+++ b/addons/cover_map/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "\x\zen\addons\cover_map\script_component.hpp"

--- a/addons/cover_map/gui.hpp
+++ b/addons/cover_map/gui.hpp
@@ -1,0 +1,86 @@
+class ctrlXSliderH;
+
+class EGVAR(common,RscLabel);
+class EGVAR(common,RscEdit);
+
+class RscMapControl {
+    class CustomMark;
+};
+
+class GVAR(RscMap): RscMapControl {
+    idc = IDC_MAP;
+
+    // Prevent map textures from being faded
+    alphaFadeStartScale = 100;
+    alphaFadeEndScale = 100;
+
+    // Allow map to be zoomed in and out more
+    scaleMin = 0.0001
+    scaleMax = 3;
+    scaleDefault = 1;
+
+    // Hide contour interval info
+    showCountourInterval = 0;
+
+    // Hide custom marker
+    class CustomMark: CustomMark {
+        icon = "#(argb,8,8,3)color(0,0,0,0)";
+        color[] = {0, 0, 0, 0};
+        size = 0;
+        importance = 0;
+        coefMin = 0;
+        coefMax = 0;
+    };
+};
+
+class EGVAR(common,RscDisplay) {
+    class controls {
+        class Title;
+        class Background;
+        class Content;
+        class ButtonOK;
+        class ButtonCancel;
+    };
+};
+
+class EGVAR(modules,RscDisplay): EGVAR(common,RscDisplay) {
+    class controls: controls {
+        class Title: Title {};
+        class Background: Background {};
+        class Content: Content {};
+        class ButtonOK: ButtonOK {};
+        class ButtonCancel: ButtonCancel {};
+    };
+};
+
+class GVAR(display): EGVAR(modules,RscDisplay) {
+    function = QFUNC(handleLoad);
+    class controls: controls {
+        class Title: Title {};
+        class Background: Background {};
+        class Content: Content {
+            // Map is created through script since map controls cannot be inside controls groups
+            // Extra height is used here so other display elements are positioned correctly
+            h = POS_H(22.1);
+            class controls {
+                class RotationLabel: EGVAR(common,RscLabel) {
+                    text = "$STR_3DEN_Object_Attribute_Rotation_displayName";
+                };
+                class RotationSlider: ctrlXSliderH {
+                    idc = IDC_ROTATION_SLIDER;
+                    x = POS_W(10.1);
+                    y = 0;
+                    w = POS_W(13.5);
+                    h = POS_H(1);
+                };
+                class RotationEdit: EGVAR(common,RscEdit) {
+                    idc = IDC_ROTATION_EDIT;
+                    x = POS_W(23.7);
+                    w = POS_W(2.3);
+                };
+            };
+        };
+        class ButtonOK: ButtonOK {};
+        class ButtonCancel: ButtonCancel {};
+    };
+};

--- a/addons/cover_map/script_component.hpp
+++ b/addons/cover_map/script_component.hpp
@@ -1,0 +1,30 @@
+#define COMPONENT cover_map
+#define COMPONENT_BEAUTIFIED Cover Map
+#include "\x\zen\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_COVER_MAP
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_COVER_MAP
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_COVER_MAP
+#endif
+
+#include "\x\zen\addons\main\script_macros.hpp"
+
+#include "\a3\ui_f\hpp\defineCommonGrids.inc"
+#include "\x\zen\addons\common\defineResinclDesign.inc"
+
+#define POS_X(N) ((N) * GUI_GRID_W + GUI_GRID_CENTER_X)
+#define POS_Y(N) ((N) * GUI_GRID_H + GUI_GRID_CENTER_Y)
+#define POS_W(N) ((N) * GUI_GRID_W)
+#define POS_H(N) ((N) * GUI_GRID_H)
+
+#define IDC_MAP 100
+#define IDC_DELETE 200
+#define IDC_ROTATION_SLIDER 300
+#define IDC_ROTATION_EDIT 400

--- a/addons/cover_map/stringtable.xml
+++ b/addons/cover_map/stringtable.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="ZEN">
+    <Package name="Cover_Map">
+        <Key ID="STR_ZEN_Cover_Map_Area_Tooltip">
+            <English>Left-click to interact with the cover map area (shaded red).\nClicking inside the area will move it and clicking outside it will create a new area.</English>
+        </Key>
+    </Package>
+</Project>

--- a/addons/modules/functions/fnc_moduleRotateObject.sqf
+++ b/addons/modules/functions/fnc_moduleRotateObject.sqf
@@ -24,17 +24,13 @@ if (isNull _object) exitWith {
     [LSTRING(NoObjectSelected)] call EFUNC(common,showMessage);
 };
 
-private _fnc_formatDegrees = {
-    format ["%1%2", round _this, toString [ASCII_DEGREE]]
-};
-
 private _yaw = [getDir _object] call CBA_fnc_simplifyAngle180;
 (_object call BIS_fnc_getPitchBank) params ["_pitch", "_roll"];
 
 [LSTRING(RotateObject), [
-    ["SLIDER", ELSTRING(common,Pitch), [-180, 180, _pitch, _fnc_formatDegrees], true],
-    ["SLIDER", ELSTRING(common,Roll), [-180, 180, _roll, _fnc_formatDegrees], true],
-    ["SLIDER", ELSTRING(common,Yaw), [-180, 180, _yaw, _fnc_formatDegrees], true]
+    ["SLIDER", ELSTRING(common,Pitch), [-180, 180, _pitch, EFUNC(common,formatDegrees)], true],
+    ["SLIDER", ELSTRING(common,Roll), [-180, 180, _roll, EFUNC(common,formatDegrees)], true],
+    ["SLIDER", ELSTRING(common,Yaw), [-180, 180, _yaw, EFUNC(common,formatDegrees)], true]
 ], {
     params ["_values", "_object"];
     _values params ["_pitch", "_roll", "_yaw"];

--- a/addons/modules/functions/fnc_moduleWeather.sqf
+++ b/addons/modules/functions/fnc_moduleWeather.sqf
@@ -62,7 +62,7 @@ params ["_logic"];
     [
         "SLIDER",
         [LSTRING(ModuleWeather_WindDirection), LSTRING(ModuleWeather_WindDirection_Tooltip)],
-        [0, 360, windDir, {format ["%1%2", round _this, toString [ASCII_DEGREE]]}],
+        [0, 360, windDir, EFUNC(common,formatDegrees)],
         true
     ],
     [


### PR DESCRIPTION
**When merged this pull request will:**
- Add a Zeus equivalent to the Cover Map module
    - Opens a dialog with a map control where the user can draw the area on the map by left-clicking
    - Close #523 
- Add common `formatDegrees` function
    - Reduce code duplication between multiple components

<details>
<summary>Image</summary>

![cover_map](https://user-images.githubusercontent.com/34453221/116794470-24dc4400-aa9b-11eb-8faa-861829b22832.png)

</details>