### PR TITLE
Cover Map - Fix IDC undef error

### DIFF
--- a/addons/cover_map/functions/fnc_handleConfirm.sqf
+++ b/addons/cover_map/functions/fnc_handleConfirm.sqf
@@ -18,7 +18,7 @@
 params ["_ctrlButtonOK"];
 
 private _display = ctrlParent _ctrlButtonOK;
-private _ctrlMap = _display displayCtrl IDC_MAP;
+private _ctrlMap = _display displayCtrl IDC_CM_MAP;
 private _area = _ctrlMap getVariable QGVAR(area);
 
 if (isNil "_area") then {

--- a/addons/cover_map/functions/fnc_handleDelete.sqf
+++ b/addons/cover_map/functions/fnc_handleDelete.sqf
@@ -18,5 +18,5 @@
 params ["_ctrlDelete"];
 
 private _display = ctrlParent _ctrlDelete;
-private _ctrlMap = _display displayCtrl IDC_MAP;
+private _ctrlMap = _display displayCtrl IDC_CM_MAP;
 _ctrlMap setVariable [QGVAR(area), nil];

--- a/addons/cover_map/functions/fnc_handleDraw.sqf
+++ b/addons/cover_map/functions/fnc_handleDraw.sqf
@@ -30,5 +30,5 @@ if (_areaExists) then {
 
 // Enable the delete button if an area exists
 private _display = ctrlParent _ctrlMap;
-private _ctrlDelete = _display displayCtrl IDC_DELETE;
+private _ctrlDelete = _display displayCtrl IDC_CM_DELETE;
 _ctrlDelete ctrlEnable _areaExists;

--- a/addons/cover_map/functions/fnc_handleLoad.sqf
+++ b/addons/cover_map/functions/fnc_handleLoad.sqf
@@ -36,7 +36,7 @@ _ctrlLabel ctrlSetPosition [_contentX, _contentY, _contentW, POS_H(1)];
 _ctrlLabel ctrlCommit 0;
 
 // Create the delete area button
-private _ctrlDelete = _display ctrlCreate ["ctrlButtonPicture", IDC_DELETE];
+private _ctrlDelete = _display ctrlCreate ["ctrlButtonPicture", IDC_CM_DELETE];
 _ctrlDelete ctrlSetText "\a3\3den\data\cfg3den\history\deleteitems_ca.paa";
 _ctrlDelete ctrlSetPosition [_contentX + _contentW - POS_W(1), _contentY, POS_W(1), POS_H(1)];
 _ctrlDelete ctrlCommit 0;
@@ -44,7 +44,7 @@ _ctrlDelete ctrlCommit 0;
 _ctrlDelete ctrlAddEventHandler ["ButtonClick", {call FUNC(handleDelete)}];
 
 // Create the map
-private _ctrlMap = _display ctrlCreate [QGVAR(RscMap), IDC_MAP];
+private _ctrlMap = _display ctrlCreate [QGVAR(RscMap), IDC_CM_MAP];
 _ctrlMap ctrlSetPosition [_contentX, _contentY + POS_H(1), _contentW, POS_H(20)];
 _ctrlMap ctrlCommit 0;
 
@@ -62,8 +62,8 @@ if (markerShape QGVAR(border) != "") then {
 };
 
 // Initialize the rotation slider and edit box
-private _ctrlSlider = _display displayCtrl IDC_ROTATION_SLIDER;
-private _ctrlEdit = _display displayCtrl IDC_ROTATION_EDIT;
+private _ctrlSlider = _display displayCtrl IDC_CM_ROTATION_SLIDER;
+private _ctrlEdit = _display displayCtrl IDC_CM_ROTATION_EDIT;
 [_ctrlSlider, _ctrlEdit, 0, 360, _angle, 15, EFUNC(common,formatDegrees), false, FUNC(handleRotationChanged)] call EFUNC(common,initSliderEdit);
 
 // Confirm changes when the OK button is clicked

--- a/addons/cover_map/functions/fnc_handleMouseButtonUp.sqf
+++ b/addons/cover_map/functions/fnc_handleMouseButtonUp.sqf
@@ -26,7 +26,7 @@ if (_button == 0) then {
     // Update the area's angle to reflect the current rotation
     // Needed to apply rotation to newly created area
     private _display = ctrlParent _ctrlMap;
-    private _ctrlSlider = _display displayCtrl IDC_ROTATION_SLIDER;
+    private _ctrlSlider = _display displayCtrl IDC_CM_ROTATION_SLIDER;
 
     private _area = _ctrlMap getVariable QGVAR(area);
     _area set [2, sliderPosition _ctrlSlider];

--- a/addons/cover_map/functions/fnc_handleRotationChanged.sqf
+++ b/addons/cover_map/functions/fnc_handleRotationChanged.sqf
@@ -20,7 +20,7 @@
 params ["_ctrlSlider", "", "_angle"];
 
 private _display = ctrlParent _ctrlSlider;
-private _ctrlMap = _display displayCtrl IDC_MAP;
+private _ctrlMap = _display displayCtrl IDC_CM_MAP;
 
 // Update the current area's angle if it exists
 private _area = _ctrlMap getVariable QGVAR(area);

--- a/addons/cover_map/gui.hpp
+++ b/addons/cover_map/gui.hpp
@@ -8,7 +8,7 @@ class RscMapControl {
 };
 
 class GVAR(RscMap): RscMapControl {
-    idc = IDC_MAP;
+    idc = IDC_CM_MAP;
 
     // Prevent map textures from being faded
     alphaFadeStartScale = 100;
@@ -67,14 +67,14 @@ class GVAR(display): EGVAR(modules,RscDisplay) {
                     text = "$STR_3DEN_Object_Attribute_Rotation_displayName";
                 };
                 class RotationSlider: ctrlXSliderH {
-                    idc = IDC_ROTATION_SLIDER;
+                    idc = IDC_CM_ROTATION_SLIDER;
                     x = POS_W(10.1);
                     y = 0;
                     w = POS_W(13.5);
                     h = POS_H(1);
                 };
                 class RotationEdit: EGVAR(common,RscEdit) {
-                    idc = IDC_ROTATION_EDIT;
+                    idc = IDC_CM_ROTATION_EDIT;
                     x = POS_W(23.7);
                     w = POS_W(2.3);
                 };

--- a/addons/cover_map/script_component.hpp
+++ b/addons/cover_map/script_component.hpp
@@ -24,7 +24,7 @@
 #define POS_W(N) ((N) * GUI_GRID_W)
 #define POS_H(N) ((N) * GUI_GRID_H)
 
-#define IDC_MAP 100
-#define IDC_DELETE 200
-#define IDC_ROTATION_SLIDER 300
-#define IDC_ROTATION_EDIT 400
+#define IDC_CM_MAP 100
+#define IDC_CM_DELETE 200
+#define IDC_CM_ROTATION_SLIDER 300
+#define IDC_CM_ROTATION_EDIT 400


### PR DESCRIPTION
**When merged this pull request will:**
- title, Mikero's tools fail to build `cover_map` component due to `IDC_MAP` collision with base game includes

```
#define IDC_MAP 100
// is: 100

//was: 51

In File \x\zen\addons\cover_map\script_component.hpp: circa Line 27 #define altered without an #undef
"cover_map.pbo not produced due to error(s)" 
```