### PR TITLE
Editor Previews - Improve support for images with non-16/9 aspect ratios

### DIFF
--- a/addons/editor_previews/functions/fnc_handleMouseUpdate.sqf
+++ b/addons/editor_previews/functions/fnc_handleMouseUpdate.sqf
@@ -34,11 +34,18 @@ if (_type isEqualTo "") then {
         _ctrlGroup ctrlShow false;
     };
 
+    getTextureInfo _image params ["_width", "_height"];
+    private _ratio = _width / _height;
+
     private _ctrlImage = _display displayCtrl IDC_PREVIEW_IMAGE;
+    _ctrlImage ctrlSetPositionW POS_W(IMAGE_HEIGHT * _ratio);
     _ctrlImage ctrlSetText _image;
+    _ctrlImage ctrlCommit 0;
 
     _ctrlGroup ctrlShow true;
-    _ctrlGroup ctrlSetPositionY (getMousePosition select 1) min (safeZoneY + safeZoneH - POS_H(5.6));
+    _ctrlGroup ctrlSetPositionX (safeZoneX + safeZoneW - POS_W(POS_EDGE(12.5,11) + IMAGE_HEIGHT * _ratio + 3 * BORDER_SIZE));
+    _ctrlGroup ctrlSetPositionY (getMousePosition select 1) min (safeZoneY + safeZoneH - POS_H(IMAGE_HEIGHT + 3 * BORDER_SIZE));
+    _ctrlGroup ctrlSetPositionW POS_W(IMAGE_HEIGHT * _ratio + 2 * BORDER_SIZE);
     _ctrlGroup ctrlCommit 0;
 };
 

--- a/addons/editor_previews/functions/fnc_initDisplayCurator.sqf
+++ b/addons/editor_previews/functions/fnc_initDisplayCurator.sqf
@@ -19,8 +19,13 @@ if (!GVAR(enabled)) exitWith {};
 
 params ["_display"];
 
+// Disable pixel rounding to fix inconsistent border size for images with different aspect ratios
 private _ctrlGroup = _display ctrlCreate [QGVAR(control), IDC_PREVIEW_GROUP];
+_ctrlGroup ctrlSetPixelPrecision 2;
 _ctrlGroup ctrlShow false;
+
+private _ctrlImage = _display displayCtrl IDC_PREVIEW_IMAGE;
+_ctrlImage ctrlSetPixelPrecision 2;
 
 {
     private _ctrlTree = _display displayCtrl _x;

--- a/addons/editor_previews/gui.hpp
+++ b/addons/editor_previews/gui.hpp
@@ -4,25 +4,25 @@ class ctrlControlsGroupNoScrollbars;
 
 class GVAR(control): ctrlControlsGroupNoScrollbars {
     idc = IDC_PREVIEW_GROUP;
-    x = safeZoneX + safeZoneW - POS_EDGE(12.5,11) * GUI_GRID_W - POS_W(9.8);
+    x = 0;
     y = 0;
-    w = POS_W(9.6);
-    h = POS_H(5.4);
+    w = 0;
+    h = POS_H(IMAGE_HEIGHT + 2 * BORDER_SIZE);
     class controls {
         class Background: ctrlStatic {
             idc = -1;
             x = 0;
             y = 0;
-            w = POS_W(9.6);
-            h = POS_H(5.4);
+            w = 1;
+            h = 1;
             colorBackground[] = {0.1, 0.1, 0.1, 0.5};
         };
         class Image: ctrlStaticPictureKeepAspect {
             idc = IDC_PREVIEW_IMAGE;
-            x = POS_W(0.1);
-            y = POS_H(0.1);
-            w = POS_W(9.4);
-            h = POS_H(5.2);
+            x = POS_W(BORDER_SIZE);
+            y = POS_H(BORDER_SIZE);
+            w = 0;
+            h = POS_H(IMAGE_HEIGHT);
         };
     };
 };

--- a/addons/editor_previews/script_component.hpp
+++ b/addons/editor_previews/script_component.hpp
@@ -26,3 +26,9 @@
 
 #define IDC_PREVIEW_GROUP 98470
 #define IDC_PREVIEW_IMAGE 98480
+
+// Height of the image - other control positions are based on this value and the aspect ratio of the image
+#define IMAGE_HEIGHT 5.2
+
+// Size of the border around the image on one side
+#define BORDER_SIZE 0.2

--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -10,7 +10,7 @@
 #define VERSION_AR  MAJOR,MINOR,PATCHLVL,BUILD
 
 // MINIMAL required version for the Mod. Components can specify others..
-#define REQUIRED_VERSION 2.04
+#define REQUIRED_VERSION 2.06
 #define REQUIRED_CBA_VERSION {3,14,0}
 
 #ifdef COMPONENT_BEAUTIFIED


### PR DESCRIPTION
**When merged this pull request will:**
- title, requires new `getTextureInfo` command (2.06)
