### PR TITLE
Improve Tracers module weapon compatibility

### DIFF
--- a/addons/modules/functions/fnc_compileTracers.sqf
+++ b/addons/modules/functions/fnc_compileTracers.sqf
@@ -23,11 +23,11 @@ private _cfgMagazineWells = configFile >> "CfgMagazineWells";
     if (
         getNumber (_x >> "scope") == 2
         && {getNumber (_x >> "type") == TYPE_WEAPON_PRIMARY}
-        && {count getArray (_x >> "muzzles") == 1}
+        && {{_x != "SAFE"} count getArray (_x >> "muzzles") == 1}
     ) then {
         private _weapon = configName _x;
 
-        if (getText (_x >> "baseWeapon") == _weapon) then {
+        if (_weapon call BIS_fnc_baseWeapon == _weapon) then {
             private _magazines = getArray (_x >> "magazines");
 
             {


### PR DESCRIPTION
**When merged this pull request will:**
- Use `BIS_fnc_baseWeapon` for better base weapon support
    - Some weapons do not have `baseWeapon` config entry explicitly defined
- Filter out `SAFE` muzzle (generally found in RHS weapons)