### PR TITLE
Improve plate number attribute condition

### DIFF
--- a/addons/attributes/initAttributes.sqf
+++ b/addons/attributes/initAttributes.sqf
@@ -194,7 +194,7 @@
         [QEGVAR(common,setPlateNumber), [_entity, _value], _entity] call CBA_fnc_targetEvent;
     },
     {getPlateNumber _entity},
-    {alive _entity && {isClass (configOf _entity >> "PlateInfos")}}
+    {alive _entity && {getText (configOf _entity >> "PlateInfos" >> "name") in selectionNames _entity}}
 ] call FUNC(addAttribute);
 
 [


### PR DESCRIPTION
**When merged this pull request will:**
- title, make plate number attribute only show for vehicles that support it
- Most vehicles have `PlateInfos` defined and `name` property also set as `"spz"`
- However, vehicles that do not support plate numbers do not have the selection