### PR TITLE
Remote Control - Add camera exit position setting

### DIFF
--- a/addons/remote_control/CfgVehicles.hpp
+++ b/addons/remote_control/CfgVehicles.hpp
@@ -1,11 +1,10 @@
 class CfgVehicles {
     class Module_F;
-    class EGVAR(modules,moduleBase);
-
     class ModuleRemoteControl_F: Module_F {
         scopeCurator = 1;
     };
 
+    class EGVAR(modules,moduleBase);
     class GVAR(module): EGVAR(modules,moduleBase) {
         curatorCanAttach = 1;
         category = "Curator";

--- a/addons/remote_control/XEH_preInit.sqf
+++ b/addons/remote_control/XEH_preInit.sqf
@@ -6,4 +6,6 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
+#include "initSettings.sqf"
+
 ADDON = true;

--- a/addons/remote_control/functions/fnc_start.sqf
+++ b/addons/remote_control/functions/fnc_start.sqf
@@ -22,13 +22,13 @@ _unit = effectiveCommander _unit;
 _unit setVariable [VAR_OWNER, player, true];
 missionNamespace setVariable [VAR_UNIT, _unit];
 
-private _cameraDir = vectorNormalized (_unit worldToModel ASLtoAGL getPosASL curatorCamera);
-private _cameraPos = _cameraDir vectorMultiply ((_unit distance curatorCamera) min MAX_CAMERA_DISTANCE);
+private _cameraPos = _unit worldToModel ASLtoAGL getPosASL curatorCamera;
+private _cameraDir = _unit vectorWorldToModel vectorDir curatorCamera;
 
-(findDisplay IDD_RSCDISPLAYCURATOR) closeDisplay 2;
+(findDisplay IDD_RSCDISPLAYCURATOR) closeDisplay IDC_CANCEL;
 
 [{
-    params ["_unit", "_cameraPos"];
+    params ["_unit", "_cameraPos", "_cameraDir"];
 
     private _vehicle = vehicle _unit;
     private _vehicleRole = assignedVehicleRole _unit;
@@ -60,11 +60,32 @@ private _cameraPos = _cameraDir vectorMultiply ((_unit distance curatorCamera) m
             || {cameraOn == vehicle player}
             || {isNull getAssignedCuratorLogic player}
         }, {
-            params ["_unit", "", "", "_cameraPos"];
+            params ["_unit", "", "", "_cameraPos", "_cameraDir"];
 
             if (!isNull _unit) then {
-                _cameraPos = _unit modelToWorld _cameraPos;
-                getAssignedCuratorLogic player setVariable ["bis_fnc_moduleCuratorSetCamera_params", [_cameraPos, _unit]];
+                private _params = switch (GVAR(cameraExitPosition)) do {
+                    case CAMERA_EXIT_UNCHANGED: {
+                        // Do nothing. Camera position remains unchanged
+                    };
+                    case CAMERA_EXIT_RELATIVE: {
+                        [_unit modelToWorld _cameraPos, _unit vectorModelToWorld _cameraDir]
+                    };
+                    case CAMERA_EXIT_RELATIVE_LIMITED: {
+                        private _offset = vectorNormalized _cameraPos vectorMultiply (vectorMagnitude _cameraPos min LIMITED_CAMERA_DISTANCE);
+                        [_unit modelToWorld _offset, _unit vectorModelToWorld _cameraDir]
+                    };
+                    case CAMERA_EXIT_ABOVE_UNIT: {
+                        [_unit modelToWorld [0, 0, 10], vectorDir _unit]
+                    };
+                    case CAMERA_EXIT_BEHIND_UNIT: {
+                        [_unit modelToWorld [0, -10, 10], _unit]
+                    };
+                };
+
+                if (!isNil "_params") then {
+                    private _curator = getAssignedCuratorLogic player;
+                    _curator setVariable ["bis_fnc_moduleCuratorSetCamera_params", _params];
+                };
             };
 
             objNull remoteControl _unit;
@@ -78,5 +99,5 @@ private _cameraPos = _cameraDir vectorMultiply ((_unit distance curatorCamera) m
 
             {openCuratorInterface} call CBA_fnc_execNextFrame;
         }, _this] call CBA_fnc_waitUntilAndExecute;
-    }, [_unit, _vehicle, _vehicleRole, _cameraPos]] call CBA_fnc_execNextFrame;
-}, [_unit, _cameraPos]] call CBA_fnc_execNextFrame;
+    }, [_unit, _vehicle, _vehicleRole, _cameraPos, _cameraDir]] call CBA_fnc_execNextFrame;
+}, [_unit, _cameraPos, _cameraDir]] call CBA_fnc_execNextFrame;

--- a/addons/remote_control/initSettings.sqf
+++ b/addons/remote_control/initSettings.sqf
@@ -1,0 +1,24 @@
+[
+    QGVAR(cameraExitPosition),
+    "LIST",
+    [LSTRING(CameraExitPosition), LSTRING(CameraExitPosition_Description)],
+    [ELSTRING(main,DisplayName), "STR_A3_CfgVehicles_ModuleRemoteControl_F"],
+    [
+        [
+            CAMERA_EXIT_UNCHANGED,
+            CAMERA_EXIT_RELATIVE,
+            CAMERA_EXIT_RELATIVE_LIMITED,
+            CAMERA_EXIT_ABOVE_UNIT,
+            CAMERA_EXIT_BEHIND_UNIT
+        ],
+        [
+            ["STR_3DEN_Attributes_Default_Unchanged_Text", LSTRING(CameraExitPosition_Unchanged_Description)],
+            [LSTRING(CameraExitPosition_Relative), LSTRING(CameraExitPosition_Relative_Description)],
+            [LSTRING(CameraExitPosition_RelativeLimited), LSTRING(CameraExitPosition_RelativeLimited_Description)],
+            [LSTRING(CameraExitPosition_AboveUnit), LSTRING(CameraExitPosition_AboveUnit_Description)],
+            [LSTRING(CameraExitPosition_BehindUnit), LSTRING(CameraExitPosition_BehindUnit_Description)]
+        ],
+        2
+    ],
+    false
+] call CBA_fnc_addSetting;

--- a/addons/remote_control/script_component.hpp
+++ b/addons/remote_control/script_component.hpp
@@ -21,4 +21,10 @@
 #define VAR_UNIT  "bis_fnc_moduleRemoteControl_unit"
 #define VAR_OWNER "bis_fnc_moduleRemoteControl_owner"
 
-#define MAX_CAMERA_DISTANCE 50
+#define CAMERA_EXIT_UNCHANGED 0
+#define CAMERA_EXIT_RELATIVE 1
+#define CAMERA_EXIT_RELATIVE_LIMITED 2
+#define CAMERA_EXIT_ABOVE_UNIT 3
+#define CAMERA_EXIT_BEHIND_UNIT 4
+
+#define LIMITED_CAMERA_DISTANCE 50

--- a/addons/remote_control/stringtable.xml
+++ b/addons/remote_control/stringtable.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="ZEN">
+    <Package name="Remote_Control">
+        <Key ID="STR_ZEN_Remote_Control_CameraExitPosition">
+            <English>Camera Exit Position</English>
+        </Key>
+        <Key ID="STR_ZEN_Remote_Control_CameraExitPosition_Description">
+            <English>Controls where the camera is positioned after exiting remote control.\nIf the unit is deleted while remote controlling, the camera's position is unchanged.</English>
+        </Key>
+        <Key ID="STR_ZEN_Remote_Control_CameraExitPosition_Unchanged_Description">
+            <English>The camera's position is unchanged and restored as it was when remote control started.</English>
+        </Key>
+        <Key ID="STR_ZEN_Remote_Control_CameraExitPosition_Relative">
+            <English>Relative</English>
+        </Key>
+        <Key ID="STR_ZEN_Remote_Control_CameraExitPosition_Relative_Description">
+            <English>The camera is positioned based on where it was relative to the unit when remote control started.</English>
+        </Key>
+        <Key ID="STR_ZEN_Remote_Control_CameraExitPosition_RelativeLimited">
+            <English>Relative (Limited)</English>
+        </Key>
+        <Key ID="STR_ZEN_Remote_Control_CameraExitPosition_RelativeLimited_Description">
+            <English>The camera is positioned based on where it was relative to the unit when remote control started but limited to a maximum distance of 50 meters from the unit.</English>
+        </Key>
+        <Key ID="STR_ZEN_Remote_Control_CameraExitPosition_AboveUnit">
+            <English>Above Unit</English>
+        </Key>
+        <Key ID="STR_ZEN_Remote_Control_CameraExitPosition_AboveUnit_Description">
+            <English>The camera is positioned 10 meters directly above the unit and facing the same direction as the unit.</English>
+        </Key>
+        <Key ID="STR_ZEN_Remote_Control_CameraExitPosition_BehindUnit">
+            <English>Behind Unit</English>
+        </Key>
+        <Key ID="STR_ZEN_Remote_Control_CameraExitPosition_BehindUnit_Description">
+            <English>The camera is positioned 10 meters behind and 10 meters above the unit and looking at the unit.</English>
+        </Key>
+    </Package>
+</Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Add "Camera Exit Position" setting to control where the Zeus camera is positioned after exiting remote control
    - Options are unchanged, relative, relative (limited to 50 m) [current behaviour], 10 m above unit, and 10 m behind and 10 m above unit (like vanilla remote control)
- Improve relative camera positioning options by accounting for the unit's direction