### PR TITLE
Remote Control - Add stopped event

### DIFF
--- a/addons/remote_control/functions/fnc_start.sqf
+++ b/addons/remote_control/functions/fnc_start.sqf
@@ -76,6 +76,8 @@ private _cameraPos = _cameraDir vectorMultiply ((_unit distance curatorCamera) m
             private _handle = player getVariable [QGVAR(handle), -1];
             player removeEventHandler ["HandleRating", _handle];
 
+            ["zen_remoteControlStopped", _unit] call CBA_fnc_localEvent;
+
             {openCuratorInterface} call CBA_fnc_execNextFrame;
         }, _this] call CBA_fnc_waitUntilAndExecute;
     }, [_unit, _vehicle, _vehicleRole, _cameraPos]] call CBA_fnc_execNextFrame;

--- a/docs/frameworks/public_events.md
+++ b/docs/frameworks/public_events.md
@@ -34,6 +34,16 @@ Executed **locally** when Zeus starts remote controlling a unit.
 
 ---
 
+#### zen_remoteControlStopped
+
+Executed **locally** when Zeus stops remote controlling a unit.
+
+**Parameters:**
+
+- 0: Unit &lt;OBJECT&gt;
+
+---
+
 #### zen_editor_modeChanged
 
 Executed **locally** when the Zeus display's create trees mode is changed.


### PR DESCRIPTION
**When merged this pull request will:**
- Add `zen_remoteControlStopped` event when remote control is stopped to complement the started event