### PR TITLE
Dialog - Fix issues when opened in 3DEN

### DIFF
--- a/addons/dialog/functions/fnc_create.sqf
+++ b/addons/dialog/functions/fnc_create.sqf
@@ -245,10 +245,17 @@ private _fnc_verifyListEntries = {
     _content set [_forEachIndex, [_controlType, _label, _tooltip, _defaultValue, _settings]];
 } forEach _content;
 
-// Exit if dialog creation fails
-if (!createDialog QEGVAR(common,RscDisplayScrollbars)) exitWith {false};
+// Use createDisplay when in 3DEN to prevent interacting with the editor's display
+private _display = if (is3DEN) then {
+    private _display3DEN = uiNamespace getVariable "Display3DEN";
+    _display3DEN createDisplay QEGVAR(common,RscDisplayScrollbars)
+} else {
+    if (!createDialog QEGVAR(common,RscDisplayScrollbars)) exitWith {displayNull};
+    uiNamespace getVariable [QEGVAR(common,display), displayNull]
+};
 
-private _display = uiNamespace getVariable QEGVAR(common,display);
+// Exit if dialog creation fails
+if (isNull _display) exitWith {false};
 
 // Set the dialog's title
 private _ctrlTitle = _display displayCtrl IDC_TITLE;


### PR DESCRIPTION
**When merged this pull request will:**
- title, Close #615 

<details>
<summary>Test Code:</summary>

```sqf
private _options = [];

for "_i" from 1 to 20 do {
    _options pushBack ["CHECKBOX", str _i, false];
};

["Example Dialog", _options, {systemChat str _this}] call zen_dialog_fnc_create;
```
</details>
