### PR TITLE
Update BIS_fnc_curatorObjectPlaced override

### DIFF
--- a/addons/editor/functions/fnc_bi_curatorObjectPlaced.sqf
+++ b/addons/editor/functions/fnc_bi_curatorObjectPlaced.sqf
@@ -19,6 +19,9 @@
 
 params ["", "_object"];
 
+//--- Flag to ignore placement script, used by Zeus composition to prevent attach and attributes popup
+if (missionNamespace getVariable ['BIS_fnc_curatorObjectPlaced_ignore', false]) exitWith {};
+
 _object call BIS_fnc_curatorAttachObject;
 BIS_fnc_curatorObjectPlaced_mouseOver = curatorMouseOver;
 


### PR DESCRIPTION
BI changed this function, we should also reflect it here.
Needed for zeus compositions to not show needless UI popups