### PR TITLE
Restrict code execution to logged in admins

### DIFF
--- a/addons/attributes/initAttributes.sqf
+++ b/addons/attributes/initAttributes.sqf
@@ -335,7 +335,7 @@
         };
     },
     {""},
-    {IS_ADMIN || {!GETMVAR(ZEN_disableCodeExecution,false)}}
+    {IS_ADMIN_LOGGED || {!GETMVAR(ZEN_disableCodeExecution,false)}}
 ] call FUNC(addAttribute);
 
 // - Group --------------------------------------------------------------------
@@ -487,7 +487,7 @@
         };
     },
     {""},
-    {IS_ADMIN || {!GETMVAR(ZEN_disableCodeExecution,false)}}
+    {IS_ADMIN_LOGGED || {!GETMVAR(ZEN_disableCodeExecution,false)}}
 ] call FUNC(addAttribute);
 
 // - Waypoint -----------------------------------------------------------------

--- a/addons/modules/functions/fnc_gui_executeCode.sqf
+++ b/addons/modules/functions/fnc_gui_executeCode.sqf
@@ -22,7 +22,7 @@
 
 params ["_display", "_logic"];
 
-if (!IS_ADMIN && {missionNamespace getVariable ["ZEN_disableCodeExecution", false]}) exitWith {
+if (!IS_ADMIN_LOGGED && {missionNamespace getVariable ["ZEN_disableCodeExecution", false]}) exitWith {
     [LSTRING(ModuleExecuteCode_Disabled)] call EFUNC(common,showMessage);
     deleteVehicle _logic;
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Restricts code execution to logged admins when disabled with `ZEN_disableCodeExecution` 