### PR TITLE
Fix 3D rotations for Attach To module

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -218,6 +218,12 @@
     _object setVectorUp _vectorUp;
 }] call CBA_fnc_addEventHandler;
 
+[QGVAR(setVectorDirAndUp), {
+    params ["_object", "_vectorDirAndUp"];
+    _object setVectorDirAndUp _vectorDirAndUp;
+}] call CBA_fnc_addEventHandler;
+
+
 [QGVAR(setVelocity), {
     params ["_object", "_velocity"];
     _object setVelocity _velocity;

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -223,7 +223,6 @@
     _object setVectorDirAndUp _vectorDirAndUp;
 }] call CBA_fnc_addEventHandler;
 
-
 [QGVAR(setVelocity), {
     params ["_object", "_velocity"];
     _object setVelocity _velocity;

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -219,8 +219,8 @@
 }] call CBA_fnc_addEventHandler;
 
 [QGVAR(setVectorDirAndUp), {
-    params ["_object", "_vectorDirAndUp"];
-    _object setVectorDirAndUp _vectorDirAndUp;
+    params ["_object", "_dirAndUp"];
+    _object setVectorDirAndUp _dirAndUp;
 }] call CBA_fnc_addEventHandler;
 
 [QGVAR(setVelocity), {

--- a/addons/modules/functions/fnc_moduleAttachTo.sqf
+++ b/addons/modules/functions/fnc_moduleAttachTo.sqf
@@ -44,10 +44,11 @@ if (!isNull attachedTo _object) exitWith {
         [LSTRING(CannotAttachToSelf)] call EFUNC(common,showMessage);
     };
 
-    private _direction = getDir _object - getDir _entity;
+    private _dirAndUp = [_entity vectorWorldToModel vectorDir _object, _entity vectorWorldToModel vectorUp _object];
 
     _object attachTo [_entity];
-    [QEGVAR(common,setDir), [_object, _direction], _object] call CBA_fnc_targetEvent;
+
+    [QEGVAR(common,setVectorDirAndUp), [_object, _dirAndUp], _object] call CBA_fnc_targetEvent;
 
     [LSTRING(ObjectAttached)] call EFUNC(common,showMessage);
 }, [], LSTRING(ModuleAttachTo)] call EFUNC(common,selectPosition);

--- a/addons/modules/functions/fnc_moduleAttachTo.sqf
+++ b/addons/modules/functions/fnc_moduleAttachTo.sqf
@@ -47,7 +47,6 @@ if (!isNull attachedTo _object) exitWith {
     private _dirAndUp = [_entity vectorWorldToModel vectorDir _object, _entity vectorWorldToModel vectorUp _object];
 
     _object attachTo [_entity];
-
     [QEGVAR(common,setVectorDirAndUp), [_object, _dirAndUp], _object] call CBA_fnc_targetEvent;
 
     [LSTRING(ObjectAttached)] call EFUNC(common,showMessage);


### PR DESCRIPTION
**When merged this pull request will:**
- Use `setVectorDirAndUp` rather than `setDir`
