### PR TITLE
Update German translation

### DIFF
--- a/addons/attributes/stringtable.xml
+++ b/addons/attributes/stringtable.xml
@@ -219,7 +219,7 @@
             <English>Skills</English>
             <Russian>Навыки</Russian>
             <French>Compétences</French>
-            <German>Fähigkeiten</German>
+            <German>Fertigkeiten</German>
             <Czech>Dovednosti</Czech>
             <Italian>Abilità</Italian>
             <Polish>Umiejętności</Polish>


### PR DESCRIPTION
Changed "Fähigkeiten" to "Fertigkeiten"

Both Abilities and Skill had the same German Translation, which made it difficult to distigush them.
I changed the STR_ZEN_Attributes_Skills to "Fertigkeiten" which is a different German translation.