### PR TITLE
Area Markers - Support editing all area markers

### DIFF
--- a/addons/area_markers/XEH_PREP.hpp
+++ b/addons/area_markers/XEH_PREP.hpp
@@ -1,10 +1,17 @@
 PREP(applyProperties);
 PREP(configure);
 PREP(createIcon);
+PREP(createMarker);
 PREP(deleteIcon);
+PREP(initDisplayCurator);
+PREP(isEditable);
 PREP(module);
 PREP(onDraw);
 PREP(onKeyDown);
+PREP(onMapToggled);
+PREP(onMarkerCreated);
+PREP(onMarkerDeleted);
+PREP(onMarkerUpdated);
 PREP(onMouseButtonDown);
 PREP(onMouseButtonUp);
 PREP(onMouseDblClick);

--- a/addons/area_markers/XEH_postInit.sqf
+++ b/addons/area_markers/XEH_postInit.sqf
@@ -1,82 +1,24 @@
 #include "script_component.hpp"
 
 if (isServer) then {
-    [QGVAR(create), {
-        params ["_position"];
-
-        private _marker = createMarker [format [QGVAR(%1), GVAR(nextID)], _position];
-        _marker setMarkerShape "RECTANGLE";
-        _marker setMarkerSize [50, 50];
-
-        GVAR(markers) pushBack _marker;
-        publicVariable QGVAR(markers);
-
-        GVAR(nextID) = GVAR(nextID) + 1;
-
-        [QGVAR(createIcon), _marker] call CBA_fnc_globalEvent;
-    }] call CBA_fnc_addEventHandler;
-
-    [QGVAR(delete), {
-        params ["_marker"];
-
-        private _index = GVAR(markers) find _marker;
-
-        if (_index != -1) then {
-            GVAR(markers) deleteAt _index;
-            publicVariable QGVAR(markers);
-
-            deleteMarker _marker;
-
-            [QGVAR(deleteIcon), _marker] call CBA_fnc_globalEvent;
-        };
-    }] call CBA_fnc_addEventHandler;
+    [QGVAR(createMarker), LINKFUNC(createMarker)] call CBA_fnc_addEventHandler;
 };
 
 if (hasInterface) then {
-    ["zen_curatorDisplayLoaded", {
-        params ["_display"];
+    ["zen_curatorDisplayLoaded", LINKFUNC(initDisplayCurator)] call CBA_fnc_addEventHandler;
 
-        // Namespace of marker names and their corresponding icon controls
-        if (isNil QGVAR(icons)) then {
-            GVAR(icons) = [] call CBA_fnc_createNamespace;
-        };
+    // Add EHs to update visibility of area marker icons when the map is toggled
+    // Need both activate and deactivate to deal with issues around rapidly toggling the map
+    addUserActionEventHandler ["showMap", "Activate", {call FUNC(onMapToggled)}];
+    addUserActionEventHandler ["showMap", "Deactivate", {call FUNC(onMapToggled)}];
 
-        // Add EH to update area marker icon positions when the map is shown
-        private _ctrlMap = _display displayCtrl IDC_RSCDISPLAYCURATOR_MAINMAP;
-        _ctrlMap ctrlAddEventHandler ["Draw", {call FUNC(onDraw)}];
+    // Add EHs to automatically make any area markers editable
+    addMissionEventHandler ["MarkerCreated", {call FUNC(onMarkerCreated)}];
+    addMissionEventHandler ["MarkerDeleted", {call FUNC(onMarkerDeleted)}];
+    addMissionEventHandler ["MarkerUpdated", {call FUNC(onMarkerUpdated)}];
 
-        // Add EH to handle deleting area marker by pressing the DELETE key
-        _display displayAddEventHandler ["KeyDown", {call FUNC(onKeyDown)}];
-
-        // Create area marker icons for all area markers
-        {
-            {
-                [_x] call FUNC(createIcon);
-            } forEach GVAR(markers);
-        } call CBA_fnc_execNextFrame;
-
-        // Add PFH to update visibility of area marker icons
-        GVAR(visiblePFH) = [{
-            params ["_args"];
-            _args params ["_visible"];
-
-            if (_visible isEqualTo visibleMap) exitWith {};
-
-            _visible = visibleMap;
-            {
-                private _ctrlIcon = GVAR(icons) getVariable [_x, controlNull];
-                _ctrlIcon ctrlShow _visible;
-            } forEach GVAR(markers);
-
-            _args set [0, _visible];
-        }, 0, [visibleMap]] call CBA_fnc_addPerFrameHandler;
-    }] call CBA_fnc_addEventHandler;
-
-    ["zen_curatorDisplayUnloaded", {
-        GVAR(visiblePFH) call CBA_fnc_removePerFrameHandler;
-    }] call CBA_fnc_addEventHandler;
-
-    [QGVAR(createIcon), LINKFUNC(createIcon)] call CBA_fnc_addEventHandler;
-    [QGVAR(deleteIcon), LINKFUNC(deleteIcon)] call CBA_fnc_addEventHandler;
-    [QGVAR(updateIcon), LINKFUNC(updateIcon)] call CBA_fnc_addEventHandler;
+    // Manually trigger event for 3DEN placed and already existent (JIP) markers
+    {
+        _x call FUNC(onMarkerCreated);
+    } forEach allMapMarkers;
 };

--- a/addons/area_markers/XEH_preInit.sqf
+++ b/addons/area_markers/XEH_preInit.sqf
@@ -7,20 +7,26 @@ PREP_RECOMPILE_START;
 PREP_RECOMPILE_END;
 
 if (isServer) then {
-    GVAR(markers) = [];
-    publicVariable QGVAR(markers);
-
+    // Unique ID for creating markers
     GVAR(nextID) = 0;
 };
 
 if (hasInterface) then {
-    GVAR(colors) = [] call CBA_fnc_createNamespace;
+    GVAR(colors) = createHashMap;
 
     {
-        if (getNumber (_x >> "scope") > 0) then {
-            GVAR(colors) setVariable [configName _x, (_x >> "color") call BIS_fnc_colorConfigToRGBA];
-        };
+        GVAR(colors) set [configName _x, (_x >> "color") call BIS_fnc_colorConfigToRGBA];
     } forEach configProperties [configFile >> "CfgMarkerColors", "isClass _x"];
+
+    // List of editable area markers
+    GVAR(markers) = [];
+
+    // List of marker names that are blacklisted from being edited through Zeus
+    // A marker is blacklisted if its name contains any of strings in this list
+    GVAR(blacklist) = [];
+
+    // Map of marker names and their corresponding icon controls
+    GVAR(icons) = createHashMap;
 };
 
 ADDON = true;

--- a/addons/area_markers/functions/fnc_applyProperties.sqf
+++ b/addons/area_markers/functions/fnc_applyProperties.sqf
@@ -42,5 +42,3 @@ _marker setMarkerColor _color;
 private _ctrlAlphaSlider = _ctrlConfigure controlsGroupCtrl IDC_CONFIGURE_ALPHA_SLIDER;
 private _alpha = sliderPosition _ctrlAlphaSlider;
 _marker setMarkerAlpha _alpha;
-
-[QGVAR(updateIcon), [_marker, _rotation, _color]] call CBA_fnc_globalEvent;

--- a/addons/area_markers/functions/fnc_configure.sqf
+++ b/addons/area_markers/functions/fnc_configure.sqf
@@ -162,6 +162,10 @@ private _keyDownEH = _display displayAddEventHandler ["KeyDown", {
             _display displayRemoveEventHandler ["KeyDown", _keyDownEH];
 
             ctrlDelete _ctrlConfigure;
+
+            // Despite returning true to override default handling, pressing ESCAPE
+            // appears to be hard coded to close the map
+            call FUNC(onMapToggled);
         };
 
         true // handled

--- a/addons/area_markers/functions/fnc_createIcon.sqf
+++ b/addons/area_markers/functions/fnc_createIcon.sqf
@@ -24,6 +24,6 @@ private _ctrlIcon = _display ctrlCreate [QGVAR(icon), IDC_ICON_GROUP];
 _ctrlIcon setVariable [QGVAR(marker), _marker];
 _ctrlIcon ctrlShow visibleMap;
 
-GVAR(icons) setVariable [_marker, _ctrlIcon];
+GVAR(icons) set [_marker, _ctrlIcon];
 
-[_marker, markerDir _marker, markerColor _marker] call FUNC(updateIcon);
+_marker call FUNC(updateIcon);

--- a/addons/area_markers/functions/fnc_createMarker.sqf
+++ b/addons/area_markers/functions/fnc_createMarker.sqf
@@ -1,0 +1,25 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Creates an area marker.
+ * Should only be called on the server for unique marker names.
+ *
+ * Arguments:
+ * 0: Position <ARRAY>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [[0, 0, 0]] call zen_area_markers_fnc_createMarker
+ *
+ * Public: No
+ */
+
+params ["_position"];
+
+private _marker = createMarker [format [QGVAR(%1), GVAR(nextID)], _position];
+_marker setMarkerShape "RECTANGLE";
+_marker setMarkerSize [50, 50];
+
+GVAR(nextID) = GVAR(nextID) + 1;

--- a/addons/area_markers/functions/fnc_deleteIcon.sqf
+++ b/addons/area_markers/functions/fnc_deleteIcon.sqf
@@ -17,9 +17,7 @@
 
 params ["_marker"];
 
-private _ctrlIcon = GVAR(icons) getVariable _marker;
-if (isNil "_ctrlIcon" || {isNull _ctrlIcon}) exitWith {};
-
-GVAR(icons) setVariable [_marker, nil];
-
-ctrlDelete _ctrlIcon;
+if (_marker in GVAR(icons)) then {
+    ctrlDelete (GVAR(icons) get _marker);
+    GVAR(icons) deleteAt _marker;
+};

--- a/addons/area_markers/functions/fnc_initDisplayCurator.sqf
+++ b/addons/area_markers/functions/fnc_initDisplayCurator.sqf
@@ -1,0 +1,32 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Initializes the Zeus display.
+ *
+ * Arguments:
+ * 0: Display <DISPLAY>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [DISPLAY] call zen_area_markers_fnc_initDisplayCurator
+ *
+ * Public: No
+ */
+
+params ["_display"];
+
+// Add EH to update area marker icon positions when the map is shown
+private _ctrlMap = _display displayCtrl IDC_RSCDISPLAYCURATOR_MAINMAP;
+_ctrlMap ctrlAddEventHandler ["Draw", {call FUNC(onDraw)}];
+
+// Add EH to handle deleting area marker by pressing the DELETE key
+_display displayAddEventHandler ["KeyDown", {call FUNC(onKeyDown)}];
+
+// Create area marker icons for all area markers
+{
+    {
+        [_x] call FUNC(createIcon);
+    } forEach GVAR(markers);
+} call CBA_fnc_execNextFrame;

--- a/addons/area_markers/functions/fnc_isEditable.sqf
+++ b/addons/area_markers/functions/fnc_isEditable.sqf
@@ -7,7 +7,7 @@
  * 0: Marker <STRING>
  *
  * Return Value:
- * None
+ * Is Editable <BOOL>
  *
  * Example:
  * ["marker_0"] call zen_area_markers_fnc_isEditable

--- a/addons/area_markers/functions/fnc_isEditable.sqf
+++ b/addons/area_markers/functions/fnc_isEditable.sqf
@@ -1,0 +1,20 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Checks if the given marker is an editable area marker.
+ *
+ * Arguments:
+ * 0: Marker <STRING>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * ["marker_0"] call zen_area_markers_fnc_isEditable
+ *
+ * Public: No
+ */
+
+params ["_marker"];
+
+markerShape _marker in ["RECTANGLE", "ELLIPSE"] && {GVAR(blacklist) findIf {_x in _marker} == -1}

--- a/addons/area_markers/functions/fnc_onDraw.sqf
+++ b/addons/area_markers/functions/fnc_onDraw.sqf
@@ -20,14 +20,10 @@ BEGIN_COUNTER(onDraw);
 params ["_ctrlMap"];
 
 {
-    private _ctrlIcon = GVAR(icons) getVariable _x;
+    (_ctrlMap ctrlMapWorldToScreen markerPos _x) params ["_posX", "_posY"];
 
-    if (!isNil "_ctrlIcon") then {
-        (_ctrlMap ctrlMapWorldToScreen markerPos _x) params ["_posX", "_posY"];
-
-        _ctrlIcon ctrlSetPosition [_posX - OFFSET_X, _posY - OFFSET_Y];
-        _ctrlIcon ctrlCommit 0;
-    };
-} forEach GVAR(markers);
+    _y ctrlSetPosition [_posX - OFFSET_X, _posY - OFFSET_Y];
+    _y ctrlCommit 0;
+} forEach GVAR(icons);
 
 END_COUNTER(onDraw);

--- a/addons/area_markers/functions/fnc_onKeyDown.sqf
+++ b/addons/area_markers/functions/fnc_onKeyDown.sqf
@@ -23,11 +23,18 @@ if (visibleMap && {_keyCode == DIK_DELETE}) exitWith {
     ctrlMapMouseOver _ctrlMap params [["_type", ""], ["_marker", ""]];
 
     if (_type == "marker" && {_marker in GVAR(markers)}) exitWith {
-        [QGVAR(delete), _marker] call CBA_fnc_serverEvent;
+        deleteMarker _marker;
         true
     };
 
     false
+};
+
+// Map visibility can be toggled with the ESCAPE key
+// Appears to be hard coded and independent of the "ingamePause" user action
+// Also, update the icons when the interface's visibility is toggled
+if (_keyCode == DIK_ESCAPE || {_keyCode in actionKeys "curatorToggleInterface"}) then {
+    call FUNC(onMapToggled);
 };
 
 false

--- a/addons/area_markers/functions/fnc_onMapToggled.sqf
+++ b/addons/area_markers/functions/fnc_onMapToggled.sqf
@@ -1,0 +1,28 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles toggling the Zeus display's map.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call zen_area_markers_fnc_onMapToggled
+ *
+ * Public: No
+ */
+
+if (isNull findDisplay IDD_RSCDISPLAYCURATOR) exitWith {};
+
+// Need frame delay because both the visisbleMap and the map control's
+// visibility are not updated until the next frame
+{
+    private _show = visibleMap && {!call EFUNC(common,isInScreenshotMode)};
+
+    {
+        _y ctrlShow _show;
+    } forEach GVAR(icons);
+} call CBA_fnc_execNextFrame;

--- a/addons/area_markers/functions/fnc_onMarkerCreated.sqf
+++ b/addons/area_markers/functions/fnc_onMarkerCreated.sqf
@@ -1,0 +1,23 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles creating a marker.
+ *
+ * Arguments:
+ * 0: Marker <STRING>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * ["marker_0"] call zen_area_markers_fnc_onMarkerCreated
+ *
+ * Public: No
+ */
+
+params ["_marker"];
+
+if (_marker call FUNC(isEditable)) then {
+    GVAR(markers) pushBack _marker;
+    _marker call FUNC(createIcon);
+};

--- a/addons/area_markers/functions/fnc_onMarkerDeleted.sqf
+++ b/addons/area_markers/functions/fnc_onMarkerDeleted.sqf
@@ -1,0 +1,21 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles deleting a marker.
+ *
+ * Arguments:
+ * 0: Marker <STRING>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * ["marker_0"] call zen_area_markers_fnc_onMarkerDeleted
+ *
+ * Public: No
+ */
+
+params ["_marker"];
+
+GVAR(markers) deleteAt (GVAR(markers) find _marker);
+_marker call FUNC(deleteIcon);

--- a/addons/area_markers/functions/fnc_onMarkerUpdated.sqf
+++ b/addons/area_markers/functions/fnc_onMarkerUpdated.sqf
@@ -1,0 +1,33 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Handles updating a marker.
+ *
+ * Arguments:
+ * 0: Marker <STRING>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * ["marker_0"] call zen_area_markers_fnc_onMarkerUpdated
+ *
+ * Public: No
+ */
+
+params ["_marker"];
+
+if (_marker call FUNC(isEditable)) then {
+    private _index = GVAR(markers) pushBackUnique _marker;
+
+    // Create icon if the marker was changed into an area marker
+    // Otherwise, just update the icon to reflect new marker properties
+    if (_index != -1) then {
+        _marker call FUNC(createIcon);
+    } else {
+        _marker call FUNC(updateIcon);
+    };
+} else {
+    GVAR(markers) deleteAt (GVAR(markers) find _marker);
+    _marker call FUNC(deleteIcon);
+};

--- a/addons/area_markers/functions/fnc_updateIcon.sqf
+++ b/addons/area_markers/functions/fnc_updateIcon.sqf
@@ -1,28 +1,26 @@
 #include "script_component.hpp"
 /*
  * Author: mharis001
- * Updates the angle and color of the given area marker's icon control.
+ * Updates the given area marker's icon control.
  *
  * Arguments:
  * 0: Marker <STRING>
- * 1: Angle <NUMBER>
- * 2: Color <STRING>
  *
  * Return Value:
  * None
  *
  * Example:
- * ["marker_0", 45, "ColorRed"] call zen_area_markers_fnc_updateIcon
+ * ["marker_0"] call zen_area_markers_fnc_updateIcon
  *
  * Public: No
  */
 
-params ["_marker", "_angle", "_color"];
+params ["_marker"];
 
-private _ctrlIcon = GVAR(icons) getVariable _marker;
-if (isNil "_ctrlIcon" || {isNull _ctrlIcon}) exitWith {};
+private _ctrlIcon = GVAR(icons) getOrDefault [_marker, controlNull];
+if (isNull _ctrlIcon) exitWith {};
 
-_ctrlIcon ctrlSetAngle [_angle, 0.5, 0.5];
+_ctrlIcon ctrlSetAngle [markerDir _marker, 0.5, 0.5];
 
 private _ctrlImage = _ctrlIcon controlsGroupCtrl IDC_ICON_IMAGE;
-_ctrlImage ctrlSetTextColor (GVAR(colors) getVariable [_color, [0, 0, 0, 1]]);
+_ctrlImage ctrlSetTextColor (GVAR(colors) get markerColor _marker);

--- a/addons/cover_map/XEH_postInit.sqf
+++ b/addons/cover_map/XEH_postInit.sqf
@@ -4,3 +4,7 @@ if (isServer) then {
     [QGVAR(create), LINKFUNC(create)] call CBA_fnc_addEventHandler;
     [QGVAR(remove), LINKFUNC(remove)] call CBA_fnc_addEventHandler;
 };
+
+if (hasInterface) then {
+    EGVAR(area_markers,blacklist) pushBack QUOTE(ADDON);
+};


### PR DESCRIPTION
**When merged this pull request will:**
- Support editing all area markers (not just those created through the module or context menu action)
    - Uses the marker mission events to track markers and automatically create editable icons for them when they are area markers
    - Handles 3DEN placed and scripted markers
    - Markers can be blacklisted using the array (used by `cover_map` currently)
- Use an event based approach for the icon visibility instead of PFH
    - A lot of edge cases but could not get it to break
    - Probably minor performance improvement
- Hide icons when the the interface is hidden (screenshot mode)
- Use `HashMap`s instead of CBA namespaces