### PR TITLE
Add snow option to Change Weather module

### DIFF
--- a/addons/modules/XEH_postInit.sqf
+++ b/addons/modules/XEH_postInit.sqf
@@ -44,34 +44,6 @@ if (isServer) then {
     _unit allowFleeing 0;
 }] call CBA_fnc_addEventHandler;
 
-[QGVAR(applyWeatherSnow), {
-    params ["_turnOnSnow"];
-
-    if (_turnOnSnow) then {
-        setRain [
-            "a3\data_f\snowflake4_ca.paa", // rainDropTexture
-            4, // texDropCount
-            0.01, // minRainDensity
-            25, // effectRadius
-            0.05, // windCoef
-            2.5, // dropSpeed
-            0.5, // rndSpeed
-            0.5, // rndDir
-            0.07, // dropWidth
-            0.07, // dropHeight
-            [1, 1, 1, 0.5], // dropColor
-            0.0, // lumSunFront
-            0.2, // lumSunBack
-            0.5, // refractCoef
-            0.5, // refractSaturation
-            true, // snow
-            false // dropColorStrong
-        ]
-    } else {
-        setRain [];
-    };
-}] call CBA_fnc_addEventHandler;
-
 [QGVAR(applyWeather), {
     params ["_forced", "_overcast", "_rain", "_lightning", "_rainbow", "_waves", "_wind", "_gusts", "_fog", ["_precipitation", -1]];
 
@@ -81,22 +53,38 @@ if (isServer) then {
     0 setWaves _waves;
     0 setGusts _gusts;
 
-    if (_precipitation == 0) then {
-        // Set rain particles to default
-        [QGVAR(applyWeatherSnow), false] call CBA_fnc_localEvent;
-    };
-
     if (isServer) then {
         0 setRain _rain;
         0 setFog _fog;
         setWind _wind;
 
-        if (_precipitation == 1) then {
-            // Broadcast globally and make JIP compatible
-            [QGVAR(applyWeatherSnow), true, QGVAR(applyWeatherSnowJIPID)] call CBA_fnc_globalEventJIP;
-        } else {
-            // Remove Event from JIP queue
-            QGVAR(applyWeatherSnowJIPID) call CBA_fnc_removeGlobalEventJIP;
+        switch (_precipitation) do {
+            // Reset to default
+            case 0: {
+                [] call BIS_fnc_setRain;
+            };
+            // Set to snow
+            case 1: {
+                [
+                    "a3\data_f\snowflake4_ca.paa", // rainDropTexture
+                    4, // texDropCount
+                    0.01, // minRainDensity
+                    25, // effectRadius
+                    0.05, // windCoef
+                    2.5, // dropSpeed
+                    0.5, // rndSpeed
+                    0.5, // rndDir
+                    0.07, // dropWidth
+                    0.07, // dropHeight
+                    [1, 1, 1, 0.5], // dropColor
+                    0.0, // lumSunFront
+                    0.2, // lumSunBack
+                    0.5, // refractCoef
+                    0.5, // refractSaturation
+                    true, // snow
+                    false // dropColorStrong
+                ] call BIS_fnc_setRain;
+            };
         };
 
         if (_forced) then {

--- a/addons/modules/XEH_postInit.sqf
+++ b/addons/modules/XEH_postInit.sqf
@@ -45,7 +45,7 @@ if (isServer) then {
 }] call CBA_fnc_addEventHandler;
 
 [QGVAR(applyWeather), {
-    params ["_forced", "_overcast", "_rain", "_lightning", "_rainbow", "_waves", "_wind", "_gusts", "_fog", ["_precipitation", -1]];
+    params ["_forced", "_overcast", "_rain", "_precipitationType", "_lightning", "_rainbow", "_waves", "_wind", "_gusts", "_fog"];
 
     0 setOvercast _overcast;
     0 setLightnings _lightning;
@@ -58,7 +58,7 @@ if (isServer) then {
         0 setFog _fog;
         setWind _wind;
 
-        switch (_precipitation) do {
+        switch (_precipitationType) do {
             // Reset to default
             case 0: {
                 [] call BIS_fnc_setRain;

--- a/addons/modules/XEH_postInit.sqf
+++ b/addons/modules/XEH_postInit.sqf
@@ -44,8 +44,36 @@ if (isServer) then {
     _unit allowFleeing 0;
 }] call CBA_fnc_addEventHandler;
 
+[QGVAR(applyWeatherSnow), {
+    params ["_turnOnSnow"];
+
+    if (_turnOnSnow) then {
+        setRain [
+            "a3\data_f\snowflake4_ca.paa", // rainDropTexture
+            4, // texDropCount
+            0.01, // minRainDensity
+            25, // effectRadius
+            0.05, // windCoef
+            2.5, // dropSpeed
+            0.5, // rndSpeed
+            0.5, // rndDir
+            0.07, // dropWidth
+            0.07, // dropHeight
+            [1, 1, 1, 0.5], // dropColor
+            0.0, // lumSunFront
+            0.2, // lumSunBack
+            0.5, // refractCoef
+            0.5, // refractSaturation
+            true, // snow
+            false // dropColorStrong
+        ]
+    } else {
+        setRain [];
+    };
+}] call CBA_fnc_addEventHandler;
+
 [QGVAR(applyWeather), {
-    params ["_forced", "_overcast", "_rain", "_lightning", "_rainbow", "_waves", "_wind", "_gusts", "_fog"];
+    params ["_forced", "_overcast", "_rain", "_lightning", "_rainbow", "_waves", "_wind", "_gusts", "_fog", ["_precipitation", -1]];
 
     0 setOvercast _overcast;
     0 setLightnings _lightning;
@@ -53,10 +81,23 @@ if (isServer) then {
     0 setWaves _waves;
     0 setGusts _gusts;
 
+    if (_precipitation == 0) then {
+        // Set rain particles to default
+        [QGVAR(applyWeatherSnow), false] call CBA_fnc_localEvent;
+    };
+
     if (isServer) then {
         0 setRain _rain;
         0 setFog _fog;
         setWind _wind;
+
+        if (_precipitation == 1) then {
+            // Broadcast globally and make JIP compatible
+            [QGVAR(applyWeatherSnow), true, QGVAR(applyWeatherSnowJIPID)] call CBA_fnc_globalEventJIP;
+        } else {
+            // Remove Event from JIP queue
+            QGVAR(applyWeatherSnowJIPID) call CBA_fnc_removeGlobalEventJIP;
+        };
 
         if (_forced) then {
             forceWeatherChange;

--- a/addons/modules/functions/fnc_moduleWeather.sqf
+++ b/addons/modules/functions/fnc_moduleWeather.sqf
@@ -31,13 +31,13 @@ params ["_logic"];
     ],
     [
         "SLIDER:PERCENT",
-        [LSTRING(ModuleWeather_Rain), LSTRING(ModuleWeather_Rain_Tooltip)],
+        [LSTRING(ModuleWeather_Precipitation), LSTRING(ModuleWeather_Precipitation_Tooltip)],
         [0, 1, rain],
         true
     ],
     [
         "TOOLBOX",
-        [LSTRING(ModuleWeather_Precipitation), LSTRING(ModuleWeather_Precipitation_Tooltip)],
+        [LSTRING(ModuleWeather_PrecipitationType), LSTRING(ModuleWeather_PrecipitationType_Tooltip)],
         [parseNumber (rainParams select 15), 1, 2, [LSTRING(ModuleWeather_Rain), LSTRING(ModuleWeather_Snow)]],
         true
     ],

--- a/addons/modules/functions/fnc_moduleWeather.sqf
+++ b/addons/modules/functions/fnc_moduleWeather.sqf
@@ -102,7 +102,7 @@ params ["_logic"];
         "_forced",
         "_overcast",
         "_rain",
-        "_precipitation",
+        "_precipitationType",
         "_lightning",
         "_rainbow",
         "_waves",

--- a/addons/modules/functions/fnc_moduleWeather.sqf
+++ b/addons/modules/functions/fnc_moduleWeather.sqf
@@ -117,7 +117,7 @@ params ["_logic"];
     private _wind = [KMH_TO_MS(_windSpeed) * sin _windDirection, KMH_TO_MS(_windSpeed) * cos _windDirection, true];
     private _fog = [_fogDensity, _fogDecay, _fogAltitude];
 
-    [QGVAR(applyWeather), [_forced, _overcast, _rain, _lightning, _rainbow, _waves, _wind, _gusts, _fog, _precipitation]] call CBA_fnc_globalEvent;
+    [QGVAR(applyWeather), [_forced, _overcast, _rain, _precipitationType, _lightning, _rainbow, _waves, _wind, _gusts, _fog]] call CBA_fnc_globalEvent;
 }, {}, [], QGVAR(moduleWeather)] call EFUNC(dialog,create);
 
 deleteVehicle _logic;

--- a/addons/modules/functions/fnc_moduleWeather.sqf
+++ b/addons/modules/functions/fnc_moduleWeather.sqf
@@ -36,6 +36,12 @@ params ["_logic"];
         true
     ],
     [
+        "TOOLBOX",
+        [LSTRING(ModuleWeather_Precipitation), LSTRING(ModuleWeather_Precipitation_Tooltip)],
+        [parseNumber (rainParams select 15), 1, 2, [LSTRING(ModuleWeather_Rain), LSTRING(ModuleWeather_Snow)]],
+        true
+    ],
+    [
         "SLIDER:PERCENT",
         [LSTRING(ModuleWeather_Lightning), LSTRING(ModuleWeather_Lightning_Tooltip)],
         [0, 1, lightnings],
@@ -96,6 +102,7 @@ params ["_logic"];
         "_forced",
         "_overcast",
         "_rain",
+        "_precipitation",
         "_lightning",
         "_rainbow",
         "_waves",
@@ -110,7 +117,7 @@ params ["_logic"];
     private _wind = [KMH_TO_MS(_windSpeed) * sin _windDirection, KMH_TO_MS(_windSpeed) * cos _windDirection, true];
     private _fog = [_fogDensity, _fogDecay, _fogAltitude];
 
-    [QGVAR(applyWeather), [_forced, _overcast, _rain, _lightning, _rainbow, _waves, _wind, _gusts, _fog]] call CBA_fnc_globalEvent;
+    [QGVAR(applyWeather), [_forced, _overcast, _rain, _lightning, _rainbow, _waves, _wind, _gusts, _fog, _precipitation]] call CBA_fnc_globalEvent;
 }, {}, [], QGVAR(moduleWeather)] call EFUNC(dialog,create);
 
 deleteVehicle _logic;

--- a/addons/modules/stringtable.xml
+++ b/addons/modules/stringtable.xml
@@ -2224,7 +2224,7 @@
             <German>Legt die Niederschlagsintensität fest, erfordert, dass die Bewölkung größer als 70% ist.</German>
         </Key>
         <Key ID="STR_ZEN_Modules_ModuleWeather_PrecipitationType">
-            <English>Precipitation type</English>
+            <English>Precipitation Type</English>
             <German>Niederschlagstyp</German>
         </Key>
         <Key ID="STR_ZEN_Modules_ModuleWeather_PrecipitationType_Tooltip">

--- a/addons/modules/stringtable.xml
+++ b/addons/modules/stringtable.xml
@@ -2212,13 +2212,24 @@
             <Italian>Coperto</Italian>
         </Key>
         <Key ID="STR_ZEN_Modules_ModuleWeather_Overcast_Tooltip">
-            <English>Sets the amount of cloud cover, higher values result in a greater likelihood of rain/storms and faster wind speeds.</English>
-            <German>Legt die Bedeckung der Wolken fest, höhere Werte führen zu einer höheren Wahrscheinlichkeit von Regen/Stürmen und schnelleren Windgeschwindigkeiten.</German>
-            <Polish>Ustala pochmurność, wysoka wartość powoduje większe prawdopodobieństwo deszczu/burzy i szybszego wiatru.</Polish>
-            <Japanese>雲が覆う量を決定します。高い値では大雨/嵐のようになり、強い風が吹きます。</Japanese>
-            <Chinesesimp>设定云量，数值越高，下雨/风暴的可能性越大，风速越快。</Chinesesimp>
-            <Chinese>設定雲量，數值越高，下雨/風暴的可能性越大，風速越快。</Chinese>
-            <Italian>Imposta la quantità di copertura nuvolosa, valori più alti comportano una maggiore probabilità di pioggia/tempeste e velocità del vento più elevate.</Italian>
+            <English>Sets the amount of cloud cover, higher values result in a greater likelihood of precipitations/storms and faster wind speeds.</English>
+            <German>Legt die Bedeckung der Wolken fest, höhere Werte führen zu einer höheren Wahrscheinlichkeit von Niederschlägen/Stürmen und schnelleren Windgeschwindigkeiten.</German>
+        </Key>
+        <Key ID="STR_ZEN_Modules_ModuleWeather_Precipitation">
+            <English>Precipitation</English>
+            <German>Niederschlag</German>
+        </Key>
+        <Key ID="STR_ZEN_Modules_ModuleWeather_Precipitation_Tooltip">
+            <English>Sets the precipitation strength, requires overcast to be greater than 70%.</English>
+            <German>Legt die Niederschlagsintensität fest, erfordert, dass die Bewölkung größer als 70% ist.</German>
+        </Key>
+        <Key ID="STR_ZEN_Modules_ModuleWeather_PrecipitationType">
+            <English>Precipitation type</English>
+            <German>Niederschlagstyp</German>
+        </Key>
+        <Key ID="STR_ZEN_Modules_ModuleWeather_PrecipitationType_Tooltip">
+            <English>Sets the type of precipitation.</English>
+            <German>Legt den Niederschlagstyp fest.</German>
         </Key>
         <Key ID="STR_ZEN_Modules_ModuleWeather_Rain">
             <English>Rain</English>
@@ -2230,29 +2241,9 @@
             <Chinese>雨</Chinese>
             <Italian>Piovere</Italian>
         </Key>
-        <Key ID="STR_ZEN_Modules_ModuleWeather_Rain_Tooltip">
-            <English>Sets the rain strength, requires overcast to be greater than 70%.</English>
-            <German>Legt die Regenstärke fest, erfordert, dass die Bewölkung größer als 70% ist.</German>
-            <Japanese>雨の強さを決定できますが、雲の量が 70% 以上でなければ動作しません。</Japanese>
-            <Polish>Ustaw intensywność deszczu, wymaga aby pochmurność była większa niż 70%.</Polish>
-            <Chinesesimp>设置降雨强度，要求云量大于70%。</Chinesesimp>
-            <Chinese>設置降雨強度，要求雲量大於70%。</Chinese>
-            <Italian>Imposta l'intensità della pioggia, richiede un cielo coperto superiore al 70%.</Italian>
-        </Key>
-        <Key ID="STR_ZEN_Modules_ModuleWeather_Precipitation">
-            <English>Precipitation</English>
-            <German>Niederschlag</German>
-            <French>Précipitation</French>
-        </Key>
-        <Key ID="STR_ZEN_Modules_ModuleWeather_Precipitation_Tooltip">
-            <English>Sets the type of precipitation.</English>
-            <German>Legt den Niederschlagstyp fest.</German>
-            <French>Défini le type de précipitation.</French>
-        </Key>
         <Key ID="STR_ZEN_Modules_ModuleWeather_Snow">
             <English>Snow</English>
             <German>Schnee</German>
-            <French>Neige</French>
         </Key>
         <Key ID="STR_ZEN_Modules_ModuleWeather_Lightning">
             <English>Lightning</English>

--- a/addons/modules/stringtable.xml
+++ b/addons/modules/stringtable.xml
@@ -2239,6 +2239,21 @@
             <Chinese>設置降雨強度，要求雲量大於70%。</Chinese>
             <Italian>Imposta l'intensità della pioggia, richiede un cielo coperto superiore al 70%.</Italian>
         </Key>
+        <Key ID="STR_ZEN_Modules_ModuleWeather_Precipitation">
+            <English>Precipitation</English>
+            <German>Niederschlag</German>
+            <French>Précipitation</French>
+        </Key>
+        <Key ID="STR_ZEN_Modules_ModuleWeather_Precipitation_Tooltip">
+            <English>Sets the type of precipitation.</English>
+            <German>Legt den Niederschlagstyp fest.</German>
+            <French>Défini le type de précipitation.</French>
+        </Key>
+        <Key ID="STR_ZEN_Modules_ModuleWeather_Snow">
+            <English>Snow</English>
+            <German>Schnee</German>
+            <French>Neige</French>
+        </Key>
         <Key ID="STR_ZEN_Modules_ModuleWeather_Lightning">
             <English>Lightning</English>
             <German>Blitzschlag</German>


### PR DESCRIPTION
**When merged this pull request will:**
- Addresses #681
- Adds a simple "Rain/Snow" option to the weather module.
- `QGVAR(applyWeather)` event is kept backwards compatible.

Notes:
- These changes might require some edits to the rain strength slider text, in order to be more clear:
At the moment, there is "Rain" to set the rain strength and "Precipitation" to set the type of precipitation, which makes me believe it could lead to some confusion.
Suggestions:
- Previously: "Rain" -> Suggested: "Precipitation"
- Previously: "Precipitation" -> Suggested: "Precipitation Type"

- The `rainParticles` can be changed (color, drop speed, etc., see [setRain,](https://community.bistudio.com/wiki/setRain) but I'm unsure what options should be added to the weather module. I didn't add any, as I felt the module might become too cluttered and maybe even complicated for some to use.
If it is wanted, so that curators can change snow particle properties, making an entirely new module just for that might be necessary.
- I haven't done much in terms of optimisation (e.g. not comparing the current precipitation state with the new one), but I'm not sure it's worth it.
- I have tested it in SP. As it's relatively simple, I doubt there should be any issues in MP, but I haven't tested it, so I can't say for certain if it's MP ready.