### PR TITLE
Improve placement preview mouse position handling

### DIFF
--- a/addons/editor/XEH_preInit.sqf
+++ b/addons/editor/XEH_preInit.sqf
@@ -9,6 +9,7 @@ PREP_RECOMPILE_END;
 #include "initSettings.sqf"
 #include "initKeybinds.sqf"
 
+GVAR(mousePos) = [0, 0];
 GVAR(clipboard) = [];
 GVAR(includeCrew) = true;
 

--- a/addons/editor/functions/fnc_handleLoad.sqf
+++ b/addons/editor/functions/fnc_handleLoad.sqf
@@ -110,6 +110,18 @@ _ctrlTreeRecent ctrlAddEventHandler ["TreeSelChanged", {
     };
 }];
 
+// Track mouse position from mouse area control to handle the mouse being over other UI elements
+// RscDisplayCurator_mousePos from base game attempts to do this but for some reason also updates when
+// the mouse is over the mission controls group
+private _fnc_updateMousePos = {
+    params ["", "_posX", "_posY"];
+    GVAR(mousePos) = [_posX, _posY];
+};
+
+private _ctrlMouseArea = _display displayCtrl IDC_RSCDISPLAYCURATOR_MOUSEAREA;
+_ctrlMouseArea ctrlAddEventHandler ["MouseMoving", _fnc_updateMousePos];
+_ctrlMouseArea ctrlAddEventHandler ["MouseHolding", _fnc_updateMousePos];
+
 // Initially open the map fully zoomed out and centered
 if (isNil QGVAR(previousMapState)) then {
     GVAR(previousMapState) = [1, [worldSize / 2, worldSize / 2]];

--- a/addons/placement/functions/fnc_updatePreview.sqf
+++ b/addons/placement/functions/fnc_updatePreview.sqf
@@ -17,11 +17,8 @@
 
 BEGIN_COUNTER(updatePreview);
 
-// Using mouse position from mouse area control to not update when mouse is over other UI elements
-private _mousePos = uiNamespace getVariable ["RscDisplayCurator_mousePos", [0, 0]];
-
 // Get terrain position and normal
-private _position = AGLtoASL screenToWorld _mousePos;
+private _position = AGLtoASL screenToWorld EGVAR(editor,mousePos);
 private _vectorUp = surfaceNormal _position;
 
 // Check if a surface other than the terrain exists


### PR DESCRIPTION
**When merged this pull request will:**
- title, fix issue with `RscDisplayCurator_mousePos` unexpectedly updating when mouse is over mission controls group

Relevant code from `RscDisplayCurator.sqf`:
```sqf
//--- Mouse area
{
	_ctrl = _display displayctrl _x;
	_ctrl ctrladdeventhandler ["mousemoving","with (uinamespace) do {RscDisplayCurator_mousePos = [_this select 1,_this select 2];};"];
	_ctrl ctrladdeventhandler ["mouseholding","with (uinamespace) do {RscDisplayCurator_mousePos = [_this select 1,_this select 2];};"];
} foreach [IDC_RSCDISPLAYCURATOR_MOUSEAREA,IDC_RSCDISPLAYCURATOR_MISSION];
```