### PR TITLE
Add ability to rotate placement preview objects

### DIFF
--- a/addons/placement/functions/fnc_handleObjectPlaced.sqf
+++ b/addons/placement/functions/fnc_handleObjectPlaced.sqf
@@ -32,10 +32,10 @@ _object allowDamage false;
 // Apply the preview object's position to the placed object after a frame
 // Helps in preventing the object from being destroyed by being moved
 [{
-    params ["_object", "_position", "_vectorDirAndUp"];
+    params ["_object", "_position", "_dirAndUp"];
 
     _object setPosASL _position;
-    _object setVectorDirAndUp  _vectorDirAndUp;
+    _object setVectorDirAndUp _dirAndUp;
     _object setVelocity [0, 0, 0];
 
     [{_this allowDamage true}, _object] call CBA_fnc_execNextFrame;

--- a/addons/placement/functions/fnc_handleObjectPlaced.sqf
+++ b/addons/placement/functions/fnc_handleObjectPlaced.sqf
@@ -32,14 +32,14 @@ _object allowDamage false;
 // Apply the preview object's position to the placed object after a frame
 // Helps in preventing the object from being destroyed by being moved
 [{
-    params ["_object", "_position", "_vectorUp"];
+    params ["_object", "_position", "_vectorDirAndUp"];
 
     _object setPosASL _position;
-    _object setVectorUp _vectorUp;
+    _object setVectorDirAndUp  _vectorDirAndUp;
     _object setVelocity [0, 0, 0];
 
     [{_this allowDamage true}, _object] call CBA_fnc_execNextFrame;
-}, [_object, getPosASL GVAR(helper), vectorUp GVAR(helper)]] call CBA_fnc_execNextFrame;
+}, [_object, getPosASL GVAR(helper), [vectorDir GVAR(helper), vectorUp GVAR(helper)]]] call CBA_fnc_execNextFrame;
 
 // Do not cancel the preview if the control key is held
 if (cba_events_control) exitWith {};

--- a/addons/placement/functions/fnc_updatePreview.sqf
+++ b/addons/placement/functions/fnc_updatePreview.sqf
@@ -21,6 +21,13 @@ BEGIN_COUNTER(updatePreview);
 private _position = AGLtoASL screenToWorld EGVAR(editor,mousePos);
 private _vectorUp = surfaceNormal _position;
 
+// Rotation mode
+if (inputAction "curatorRotateMod" > 0) exitWith {
+    GVAR(helper) setDir (GVAR(helper) getDir _position);
+
+    END_COUNTER(updatePreview);
+};
+
 // Check if a surface other than the terrain exists
 {
     _x params ["_intersectPos", "_surfaceNormal"];

--- a/addons/placement/functions/fnc_updatePreview.sqf
+++ b/addons/placement/functions/fnc_updatePreview.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /*
- * Author: Brett, mharis001
+ * Author: Brett, mharis001, Ampersand
  * Updates the placement preview based on the current mouse position.
  *
  * Arguments:
@@ -17,30 +17,43 @@
 
 BEGIN_COUNTER(updatePreview);
 
-// Get terrain position and normal
-private _position = AGLtoASL screenToWorld EGVAR(editor,mousePos);
-private _vectorUp = surfaceNormal _position;
-
-// Rotation mode
-if (inputAction "curatorRotateMod" > 0) exitWith {
-    GVAR(helper) setDir (GVAR(helper) getDir _position);
-
-    END_COUNTER(updatePreview);
-};
-
-// Check if a surface other than the terrain exists
-{
-    _x params ["_intersectPos", "_surfaceNormal"];
-
-    // Use the intersection position and normal if the surface is relatively flat
-    if (_surfaceNormal vectorDotProduct [0, 0, 1] > 0.5) exitWith {
-        _position = _intersectPos;
-        _vectorUp = _surfaceNormal;
-    };
-} forEach lineIntersectsSurfaces [getPosASL curatorCamera, _position, GVAR(helper), GVAR(object), true, 5];
-
 // Update the helper, which will update the attached preview object
-GVAR(helper) setPosASL _position;
-GVAR(helper) setVectorUp _vectorUp;
+// Rotate the object when the rotation modifier is held down
+if (inputAction "curatorRotateMod" > 0) then {
+    private _screenPos = worldToScreen ASLToAGL getPosASL GVAR(helper);
+
+    // If the object is onscreen, then calculate the direction based on its screen position
+    // Otherwise, fall back to using the mouse's world positon, which can behave weirdly at certain
+    // camera angles but should not be the case with the object offscreen
+    private _direction = if (_screenPos isNotEqualTo []) then {
+        private _vector = _screenPos vectorDiff EGVAR(editor,mousePos);
+        _vector params ["_vectorX", "_vectorY"];
+
+        // Translate to north as 0 degrees and account for camera view direction
+        _vectorY atan2 _vectorX - 90 + getDir curatorCamera
+    } else {
+        GVAR(helper) getDir screenToWorld EGVAR(editor,mousePos)
+    };
+
+    GVAR(helper) setDir _direction;
+} else {
+    // Get terrain position and normal
+    private _position = AGLToASL screenToWorld EGVAR(editor,mousePos);
+    private _vectorUp = surfaceNormal _position;
+
+    // Check if a surface other than the terrain exists
+    {
+        _x params ["_intersectPos", "_surfaceNormal"];
+
+        // Use the intersection position and normal if the surface is relatively flat
+        if (_surfaceNormal vectorDotProduct [0, 0, 1] > 0.5) exitWith {
+            _position = _intersectPos;
+            _vectorUp = _surfaceNormal;
+        };
+    } forEach lineIntersectsSurfaces [getPosASL curatorCamera, _position, GVAR(helper), GVAR(object), true, 5];
+
+    GVAR(helper) setPosASL _position;
+    GVAR(helper) setVectorUp _vectorUp;
+};
 
 END_COUNTER(updatePreview);


### PR DESCRIPTION
**When merged this pull request will:**
- Enable rotation of placement preview when holding Zeus rotation modifier, default L Shift
- Preview rotation is preserved if Shift is released
- Object can be placed while Shift is held down
- Object rotation matches preview