### PR TITLE
Fix select position ignoring overlapping controls

### DIFF
--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -39,6 +39,7 @@ PREP(initListNBoxSorting);
 PREP(initOwnersControl);
 PREP(initSidesControl);
 PREP(initSliderEdit);
+PREP(isCursorOnMouseArea);
 PREP(isInScreenshotMode);
 PREP(isPlacementActive);
 PREP(isRemoteControlled);

--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -6,6 +6,8 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
+GVAR(mousePos) = [0, 0];
+
 GVAR(aceMedical) = isClass (configFile >> "CfgPatches" >> "ace_medical");
 GVAR(aceMedicalTreatment) = isClass (configFile >> "CfgPatches" >> "ace_medical_treatment");
 

--- a/addons/common/functions/fnc_displayCuratorLoad.sqf
+++ b/addons/common/functions/fnc_displayCuratorLoad.sqf
@@ -22,5 +22,17 @@ if (GVAR(disableGearAnim) && {vehicle player == player}) then {
     [{player switchMove _this}, animationState player] call CBA_fnc_execNextFrame;
 };
 
+// Track mouse position from mouse area control to handle the mouse being over other UI elements
+// RscDisplayCurator_mousePos from base game attempts to do this but for some reason also updates when
+// the mouse is over the mission controls group
+private _fnc_updateMousePos = {
+    params ["", "_posX", "_posY"];
+    GVAR(mousePos) = [_posX, _posY];
+};
+
+private _ctrlMouseArea = _display displayCtrl IDC_RSCDISPLAYCURATOR_MOUSEAREA;
+_ctrlMouseArea ctrlAddEventHandler ["MouseMoving", _fnc_updateMousePos];
+_ctrlMouseArea ctrlAddEventHandler ["MouseHolding", _fnc_updateMousePos];
+
 // Emit display load event
 ["zen_curatorDisplayLoaded", _display] call CBA_fnc_localEvent;

--- a/addons/common/functions/fnc_isCursorOnMouseArea.sqf
+++ b/addons/common/functions/fnc_isCursorOnMouseArea.sqf
@@ -1,0 +1,22 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Checks if the Zeus display's cursor is currently hovering over
+ * the mouse area (or the map) without any other overlapping controls
+ * such as the create or edit trees.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * On Mouse Area <BOOL>
+ *
+ * Example:
+ * [] call zen_common_fnc_isCursorOnMouseArea
+ *
+ * Public: No
+ */
+
+private _display = findDisplay IDD_RSCDISPLAYCURATOR;
+private _ctrlIDC = ctrlIDC (_display ctrlAt getMousePosition);
+_ctrlIDC in [IDC_RSCDISPLAYCURATOR_MOUSEAREA, IDC_RSCDISPLAYCURATOR_MAINMAP]

--- a/addons/common/functions/fnc_selectPosition.sqf
+++ b/addons/common/functions/fnc_selectPosition.sqf
@@ -79,9 +79,9 @@ private _visuals = [_text, _icon, _angle, _color];
 private _mouseEH = [_display, "MouseButtonDown", {
     params ["", "_button", "", "", "_shift", "_ctrl", "_alt"];
 
-    if (_button != 0) exitWith {};
+    if (_button != 0 || {!call FUNC(isCursorOnMouseArea)}) exitWith {};
 
-    private _position = [nil, 2] call FUNC(getPosFromScreen);
+    private _position = [GVAR(mousePos), 2] call FUNC(getPosFromScreen);
     _thisArgs params ["_objects", "_function", "_args"];
 
     [true, _objects, _position, _args, _shift, _ctrl, _alt] call _function;
@@ -94,7 +94,7 @@ private _keyboardEH = [_display, "KeyDown", {
 
     if (_key != DIK_ESCAPE) exitWith {false};
 
-    private _position = [nil, 2] call FUNC(getPosFromScreen);
+    private _position = [GVAR(mousePos), 2] call FUNC(getPosFromScreen);
     _thisArgs params ["_objects", "_function", "_args"];
 
     [false, _objects, _position, _args, _shift, _ctrl, _alt] call _function;
@@ -108,7 +108,7 @@ private _drawEH = [_ctrlMap, "Draw", {
     params ["_ctrlMap"];
     _thisArgs params ["_objects", "_args", "_visuals", "_modifierFunction"];
 
-    private _position = [nil, 2] call FUNC(getPosFromScreen);
+    private _position = [GVAR(mousePos), 2] call FUNC(getPosFromScreen);
     [_objects, _position, _args, _visuals] call _modifierFunction;
     _visuals params ["_text", "_icon", "_angle", "_color"];
 
@@ -155,7 +155,7 @@ private _drawEH = [_ctrlMap, "Draw", {
     // No 3D drawing needed if the map is visible
     if (visibleMap) exitWith {};
 
-    private _position = [nil, 2] call FUNC(getPosFromScreen);
+    private _position = [GVAR(mousePos), 2] call FUNC(getPosFromScreen);
     [_objects, _position, _args, _visuals] call _modifierFunction;
     _visuals params ["_text", "_icon", "_angle", "_color"];
 

--- a/addons/editor/XEH_preInit.sqf
+++ b/addons/editor/XEH_preInit.sqf
@@ -9,7 +9,6 @@ PREP_RECOMPILE_END;
 #include "initSettings.sqf"
 #include "initKeybinds.sqf"
 
-GVAR(mousePos) = [0, 0];
 GVAR(clipboard) = [];
 GVAR(includeCrew) = true;
 

--- a/addons/editor/functions/fnc_handleLoad.sqf
+++ b/addons/editor/functions/fnc_handleLoad.sqf
@@ -110,18 +110,6 @@ _ctrlTreeRecent ctrlAddEventHandler ["TreeSelChanged", {
     };
 }];
 
-// Track mouse position from mouse area control to handle the mouse being over other UI elements
-// RscDisplayCurator_mousePos from base game attempts to do this but for some reason also updates when
-// the mouse is over the mission controls group
-private _fnc_updateMousePos = {
-    params ["", "_posX", "_posY"];
-    GVAR(mousePos) = [_posX, _posY];
-};
-
-private _ctrlMouseArea = _display displayCtrl IDC_RSCDISPLAYCURATOR_MOUSEAREA;
-_ctrlMouseArea ctrlAddEventHandler ["MouseMoving", _fnc_updateMousePos];
-_ctrlMouseArea ctrlAddEventHandler ["MouseHolding", _fnc_updateMousePos];
-
 // Initially open the map fully zoomed out and centered
 if (isNil QGVAR(previousMapState)) then {
     GVAR(previousMapState) = [1, [worldSize / 2, worldSize / 2]];

--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -10,7 +10,7 @@
 #define VERSION_AR  MAJOR,MINOR,PATCHLVL,BUILD
 
 // MINIMAL required version for the Mod. Components can specify others..
-#define REQUIRED_VERSION 2.10
+#define REQUIRED_VERSION 2.12
 #define REQUIRED_CBA_VERSION {3,15,8}
 
 #ifdef COMPONENT_BEAUTIFIED

--- a/addons/placement/functions/fnc_updatePreview.sqf
+++ b/addons/placement/functions/fnc_updatePreview.sqf
@@ -26,19 +26,19 @@ if (inputAction "curatorRotateMod" > 0) then {
     // Otherwise, fall back to using the mouse's world positon, which can behave weirdly at certain
     // camera angles but should not be the case with the object offscreen
     private _direction = if (_screenPos isNotEqualTo []) then {
-        private _vector = _screenPos vectorDiff EGVAR(editor,mousePos);
+        private _vector = _screenPos vectorDiff EGVAR(common,mousePos);
         _vector params ["_vectorX", "_vectorY"];
 
         // Translate to north as 0 degrees and account for camera view direction
         _vectorY atan2 _vectorX - 90 + getDir curatorCamera
     } else {
-        GVAR(helper) getDir screenToWorld EGVAR(editor,mousePos)
+        GVAR(helper) getDir screenToWorld EGVAR(common,mousePos)
     };
 
     GVAR(helper) setDir _direction;
 } else {
     // Get terrain position and normal
-    private _position = AGLToASL screenToWorld EGVAR(editor,mousePos);
+    private _position = AGLToASL screenToWorld EGVAR(common,mousePos);
     private _vectorUp = surfaceNormal _position;
 
     // Check if a surface other than the terrain exists


### PR DESCRIPTION
**When merged this pull request will:**
- title, mimics the behaviour of entity placement
    - Close #392 
- Add `isCursorOnMouseArea` common function (maybe there is a better name)
- Move mouse position tracking from `editor` to `common`
- Requires new `ctrlAt` command from 2.12