### PR TITLE
Add CQB mode to Move camera to selected entity key

### DIFF
--- a/addons/editor/XEH_PREP.hpp
+++ b/addons/editor/XEH_PREP.hpp
@@ -2,6 +2,7 @@ PREP(addGroupIcons);
 PREP(addModIcons);
 PREP(declutterEmptyTree);
 PREP(fixSideButtons);
+PREP(handleCuratorMoveCamTo);
 PREP(handleKeyDown);
 PREP(handleLoad);
 PREP(handleModeButtons);

--- a/addons/editor/XEH_postInit.sqf
+++ b/addons/editor/XEH_postInit.sqf
@@ -3,3 +3,4 @@
 ["zen_curatorDisplayLoaded", LINKFUNC(handleLoad)] call CBA_fnc_addEventHandler;
 ["zen_curatorDisplayUnloaded", LINKFUNC(handleUnload)] call CBA_fnc_addEventHandler;
 [QGVAR(modeChanged), LINKFUNC(fixSideButtons)] call CBA_fnc_addEventHandler;
+addUserActionEventHandler ["curatorMoveCamTo", "Deactivate", LINKFUNC(handleCuratorMoveCamTo)];

--- a/addons/editor/functions/fnc_handleCuratorMoveCamTo.sqf
+++ b/addons/editor/functions/fnc_handleCuratorMoveCamTo.sqf
@@ -1,0 +1,31 @@
+#include "script_component.hpp"
+/*
+ * Author: Ampersand
+ * Handles the behaviour of the curatorMoveCamTo user action.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call zen_editor_fnc_handleCuratorMoveCamTo
+ *
+ * Public: No
+ */
+
+private _selectedObjects = curatorSelected select 0;
+if (count _selectedObjects == 0) exitWith {};
+
+private _selectedObject = _selectedObjects select 0;
+if (isNil QGVAR(curatorMovedCamTo) || {_selectedObject != GVAR(curatorMovedCamTo)}) exitWith {
+    GVAR(curatorMovedCamTo) = _selectedObject;
+};
+
+// Second activation of curatorMoveCamTo on same object
+(0 boundingBoxReal GVAR(curatorMovedCamTo)) params ["_p1", "_p2"];
+// Move camera to top-rear of object bounding box for CQB view
+curatorCamera setPosASL (GVAR(curatorMovedCamTo) modelToWorldVisualWorld [0, _p1 select 1, _p2 select 2]);
+curatorCamera setDir getDir GVAR(curatorMovedCamTo);
+GVAR(curatorMovedCamTo) = nil;


### PR DESCRIPTION
**When merged this pull request will:**
- Add alternate mode for Move camera to selected entity key
- CQB mode moves camera to top-rear of object bounding box Useful when unit is inside multi-floor structure
- Repeated keypresses switch between modes
- https://youtu.be/TQgj4HmbUnw
