### PR TITLE
Add Toggle Object Editability keybind

### DIFF
--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -63,3 +63,4 @@ PREP(setVehicleAmmo);
 PREP(showMessage);
 PREP(spawnLargeObject);
 PREP(teleportIntoVehicle);
+PREP(updateEditableObjects);

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -360,30 +360,6 @@ if (isServer) then {
         _waypoint setWaypointSpeed _speedMode;
     }] call CBA_fnc_addEventHandler;
 
-    [QGVAR(addObjects), {
-        params ["_objects", ["_curator", objNull]];
-
-        if (!isNull _curator) exitWith {
-            _curator addCuratorEditableObjects [_objects, true];
-        };
-
-        {
-            _x addCuratorEditableObjects [_objects, true];
-        } forEach allCurators;
-    }] call CBA_fnc_addEventHandler;
-
-    [QGVAR(removeObjects), {
-        params ["_objects", ["_curator", objNull]];
-
-        if (!isNull _curator) exitWith {
-            _curator removeCuratorEditableObjects [_objects, true];
-        };
-
-        {
-            _x removeCuratorEditableObjects [_objects, true];
-        } forEach allCurators;
-    }] call CBA_fnc_addEventHandler;
-
     {
         ["AllVehicles", "InitPost", {
             params ["_object"];
@@ -408,4 +384,5 @@ if (isServer) then {
 
     [QGVAR(createZeus), LINKFUNC(createZeus)] call CBA_fnc_addEventHandler;
     [QGVAR(deserializeObjects), LINKFUNC(deserializeObjects)] call CBA_fnc_addEventHandler;
+    [QGVAR(updateEditableObjects), LINKFUNC(updateEditableObjects)] call CBA_fnc_addEventHandler;
 };

--- a/addons/common/functions/fnc_deserializeObjects.sqf
+++ b/addons/common/functions/fnc_deserializeObjects.sqf
@@ -285,7 +285,7 @@ private _fnc_deserializeObject = {
 } forEach _objectData;
 
 if (_makeEditable) then {
-    [QGVAR(addObjects), [_objects]] call CBA_fnc_serverEvent;
+    [_objects] call FUNC(updateEditableObjects);
 };
 
 _objects

--- a/addons/common/functions/fnc_updateEditableObjects.sqf
+++ b/addons/common/functions/fnc_updateEditableObjects.sqf
@@ -1,0 +1,54 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Updates editable objects for the given (or all) curators.
+ *
+ * Arguments:
+ * 0: Object(s) <ARRAY|OBJECT>
+ * 1: Mode <BOOL> (default: true)
+ *   - true: add objects, false: remove objects.
+ * 2: Curator(s) <ARRAY|OBJECT> (default: [])
+ *   - When given [] or objNull, changes are applied to all curators.
+ * 3: Include Crew <BOOL> (default: true)
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [_objects, true] call zen_common_fnc_updateEditableObjects
+ *
+ * Public: No
+ */
+
+if (!isServer) exitWith {
+    [QGVAR(updateEditableObjects), _this] call CBA_fnc_serverEvent;
+};
+
+params [
+    ["_objects", [], [[], objNull]],
+    ["_mode", true, [true]],
+    ["_curators", [], [[], objNull]],
+    ["_includeCrew", true, [true]]
+];
+
+if (_objects isEqualType objNull) then {
+    _objects = [_objects];
+};
+
+if (_curators in [[], objNull]) then {
+    _curators = allCurators;
+};
+
+if (_curators isEqualType objNull) then {
+    _curators = [_curators];
+};
+
+if (_mode) then {
+    {
+        _x addCuratorEditableObjects [_objects, _includeCrew];
+    } forEach _curators;
+} else {
+    {
+        _x removeCuratorEditableObjects [_objects, _includeCrew];
+    } forEach _curators;
+};

--- a/addons/context_actions/functions/fnc_openEditableObjectsDialog.sqf
+++ b/addons/context_actions/functions/fnc_openEditableObjectsDialog.sqf
@@ -19,5 +19,4 @@ params ["_position"];
 
 private _logic = QEGVAR(modules,moduleEditableObjects) createVehicleLocal [0, 0, 0];
 _logic setPosASL _position;
-
 _logic call BIS_fnc_showCuratorAttributes;

--- a/addons/context_actions/functions/fnc_updateEditableObjects.sqf
+++ b/addons/context_actions/functions/fnc_updateEditableObjects.sqf
@@ -12,7 +12,7 @@
  * None
  *
  * Example:
- * [true, [0, 0, 0], 100] call zen_context_actions_fnc_editableObjects
+ * [true, [0, 0, 0], 100] call zen_context_actions_fnc_updateEditableObjects
  *
  * Public: No
  */
@@ -21,6 +21,4 @@ params ["_mode", "_position", "_radius"];
 
 private _curator = getAssignedCuratorLogic player;
 private _objects = nearestObjects [ASLtoAGL _position, ["All"], _radius, true];
-private _eventName = [QEGVAR(common,removeObjects), QEGVAR(common,addObjects)] select _mode;
-
-[_eventName, [_objects, _curator]] call CBA_fnc_serverEvent;
+[_objects, _mode, _curator] call EFUNC(common,updateEditableObjects);

--- a/addons/editor/initKeybinds.sqf
+++ b/addons/editor/initKeybinds.sqf
@@ -87,6 +87,30 @@
     };
 }, {}, [DIK_X, [false, true, false]]] call CBA_fnc_addKeybind; // Default: CTRL + X
 
+[ELSTRING(main,DisplayName), QGVAR(toggleEditability), [LSTRING(ToggleEditability), LSTRING(ToggleEditability_Description)], {
+    if (!isNull curatorCamera && {!GETMVAR(RscDisplayCurator_search,false)}) then {
+        curatorMouseOver params ["_type", "_entity"];
+
+        private _object = if (_type != "OBJECT") then {
+            if (!call EFUNC(common,isCursorOnMouseArea)) exitWith {objNull};
+
+            private _begPos = getPosASL curatorCamera;
+            private _endPos = AGLToASL screenToWorld getMousePosition;
+            lineIntersectsSurfaces [_begPos, _endPos, curatorCamera] param [0, []] param [2, objNull]
+        } else {
+            _entity
+        };
+
+        if (!isNull _object) then {
+            private _curator = getAssignedCuratorLogic player;
+            private _isEditable = _object in curatorEditableObjects _curator;
+            [_object, !_isEditable, _curator] call EFUNC(common,updateEditableObjects);
+        };
+
+        true // handled
+    };
+}, {}, [0, [false, false, false]]] call CBA_fnc_addKeybind; // Default: Unbound
+
 [ELSTRING(main,DisplayName), QGVAR(toggleIcons), [LSTRING(ToggleIcons), LSTRING(ToggleIcons_Description)], {
     if (!isNull curatorCamera && {!GETMVAR(RscDisplayCurator_search,false)}) then {
         GVAR(iconsVisible) = !GVAR(iconsVisible);

--- a/addons/editor/stringtable.xml
+++ b/addons/editor/stringtable.xml
@@ -332,6 +332,12 @@
             <Chinese>調整所有被選中的物體的方向，使之與它們位置上的地形坡度一致。</Chinese>
             <Italian>Orienta tutti gli oggetti selezionati in modo che corrispondano alla pendenza del terreno nella loro posizione.</Italian>
         </Key>
+        <Key ID="STR_ZEN_Editor_ToggleEditability">
+            <English>Toggle Object Editability</English>
+        </Key>
+        <Key ID="STR_ZEN_Editor_ToggleEditability_Description">
+            <English>Toggles the editability (i.e., whether an object is editable through Zeus) of the object currently under the cursor.</English>
+        </Key>
         <Key ID="STR_ZEN_Editor_ToggleIcons">
             <English>Toggle Editable Icons</English>
             <German>Bearbeitbare Symbole umschalten</German>

--- a/addons/modules/functions/fnc_moduleAmbientFlyby.sqf
+++ b/addons/modules/functions/fnc_moduleAmbientFlyby.sqf
@@ -114,4 +114,4 @@ _waypoint setWaypointSpeed _speed;
 _waypoint setWaypointStatements ["true", "private _group = group this; private _aircrafts = []; {_aircrafts pushBackUnique vehicle _x; deleteVehicle _x} forEach thisList; {deleteVehicle _x} forEach _aircrafts; deleteGroup _group"];
 
 // Add aircrafts to curators
-[QEGVAR(common,addObjects), [_aircrafts]] call CBA_fnc_serverEvent;
+[_aircrafts] call EFUNC(common,updateEditableObjects);

--- a/addons/modules/functions/fnc_moduleCreateIntel.sqf
+++ b/addons/modules/functions/fnc_moduleCreateIntel.sqf
@@ -105,7 +105,7 @@ if (isNull _object) then {
 
     if (_object isEqualType []) then {
         _object = createVehicle [_values deleteAt 0, _object, [], 0, "NONE"];
-        [QEGVAR(common,addObjects), [[_object]]] call CBA_fnc_serverEvent;
+        _object call EFUNC(common,updateEditableObjects);
     };
 
     // Handle no action type option when ACE is not loaded

--- a/addons/modules/functions/fnc_moduleCreateMinefield.sqf
+++ b/addons/modules/functions/fnc_moduleCreateMinefield.sqf
@@ -79,7 +79,7 @@ _minesCache params ["_configNames", "_displayNames"];
     };
 
     // Add created mines to editable objects
-    [QEGVAR(common,addObjects), [_mines]] call CBA_fnc_serverEvent;
+    [_mines] call EFUNC(common,updateEditableObjects);
 }, {}, ASLtoAGL getPosASL _logic] call EFUNC(dialog,create);
 
 deleteVehicle _logic;

--- a/addons/modules/functions/fnc_moduleCreateTeleporterServer.sqf
+++ b/addons/modules/functions/fnc_moduleCreateTeleporterServer.sqf
@@ -22,7 +22,7 @@ params ["_object", "_position", "_name"];
 // Create a flag pole object if an object wasn't given
 if (isNull _object) then {
     _object = createVehicle ["FlagPole_F", _position, [], 0, "NONE"];
-    [QEGVAR(common,addObjects), [[_object]]] call CBA_fnc_localEvent;
+    _object call EFUNC(common,updateEditableObjects);
 };
 
 // Add teleport action to new teleporter object

--- a/addons/modules/functions/fnc_moduleEditableObjects.sqf
+++ b/addons/modules/functions/fnc_moduleEditableObjects.sqf
@@ -62,5 +62,4 @@ if (_range == -1) then {
     _objects = nearestObjects [_position, _types, _range, true];
 };
 
-private _eventName = [QEGVAR(common,removeObjects), QEGVAR(common,addObjects)] select _editingMode;
-[_eventName, [_objects, _curator]] call CBA_fnc_serverEvent;
+[_objects, _editingMode, _curator] call EFUNC(common,updateEditableObjects);

--- a/addons/modules/functions/fnc_moduleEffectFireLocal.sqf
+++ b/addons/modules/functions/fnc_moduleEffectFireLocal.sqf
@@ -28,7 +28,7 @@ _color params ["_colorRed", "_colorGreen", "_colorBlue"];
 
 if (isServer) then {
     // Add logic object to all curators for QOL
-    [QEGVAR(common,addObjects), [[_logic]]] call CBA_fnc_localEvent;
+    [_logic] call EFUNC(common,updateEditableObjects);
 
     // Create global fire sound effect if not created yet
     private _sound = _logic getVariable QGVAR(fireSound);

--- a/addons/modules/functions/fnc_moduleLightSource.sqf
+++ b/addons/modules/functions/fnc_moduleLightSource.sqf
@@ -47,7 +47,7 @@ _display closeDisplay IDC_CANCEL; // Close helper display
             _logic setVariable [QGVAR(lightpoint), _lightpoint, true];
 
             // Add logic object to all curators once it has lightpoint for QOL
-            [QEGVAR(common,addObjects), [[_logic]]] call CBA_fnc_serverEvent;
+            [_logic] call EFUNC(common,updateEditableObjects);
 
             // Add event handler to delete lightpoint if logic is deleted
             [QEGVAR(common,execute), [{

--- a/addons/modules/functions/fnc_moduleSitOnChair.sqf
+++ b/addons/modules/functions/fnc_moduleSitOnChair.sqf
@@ -139,7 +139,7 @@ private _displayNames = _configNames apply {getText (_cfgVehicles >> _x >> "disp
     [QEGVAR(common,setDir), [_unit, _sitDirection], _unit] call CBA_fnc_targetEvent;
 
     // Add chair to editable objects so it can be moved around
-    [QEGVAR(common,addObjects), [[_chair]]] call CBA_fnc_serverEvent;
+    [_chair] call EFUNC(common,updateEditableObjects);
 
     // Flag unit as sitting so module will make it stand up next time
     _unit setVariable [QGVAR(isSitting), true, true];

--- a/addons/modules/functions/fnc_moduleSpawnCarrier.sqf
+++ b/addons/modules/functions/fnc_moduleSpawnCarrier.sqf
@@ -31,7 +31,7 @@ params ["_logic"];
         private _jipID = [QGVAR(carrierInit), _carrier] call CBA_fnc_globalEventJIP;
         [_jipID, _carrier] call CBA_fnc_removeGlobalEventJIP;
 
-        [QEGVAR(common,addObjects), [[_carrier]]] call CBA_fnc_serverEvent;
+        [_carrier] call EFUNC(common,updateEditableObjects);
 
         {
             deleteVehicle _x;

--- a/addons/modules/functions/fnc_moduleSpawnDestroyer.sqf
+++ b/addons/modules/functions/fnc_moduleSpawnDestroyer.sqf
@@ -31,7 +31,7 @@ params ["_logic"];
         private _jipID = [QGVAR(destroyerInit), _destroyer] call CBA_fnc_globalEventJIP;
         [_jipID, _destroyer] call CBA_fnc_removeGlobalEventJIP;
 
-        [QEGVAR(common,addObjects), [[_destroyer]]] call CBA_fnc_serverEvent;
+        [_destroyer] call EFUNC(common,updateEditableObjects);
 
         {
             deleteVehicle _x;

--- a/addons/modules/functions/fnc_moduleSpawnReinforcements.sqf
+++ b/addons/modules/functions/fnc_moduleSpawnReinforcements.sqf
@@ -139,4 +139,4 @@ private _objects = [_vehicle];
 _objects append units _vehicleGroup;
 _objects append units _infantryGroup;
 
-[QEGVAR(common,addObjects), [_objects]] call CBA_fnc_serverEvent;
+[_objects] call EFUNC(common,updateEditableObjects);

--- a/addons/position_logics/functions/fnc_add.sqf
+++ b/addons/position_logics/functions/fnc_add.sqf
@@ -40,7 +40,7 @@ if (isServer) then {
     [_jipID, _logic] call CBA_fnc_removeGlobalEventJIP;
 
     // Make the logic editable for all curators
-    [QEGVAR(common,addObjects), [[_logic]]] call CBA_fnc_localEvent;
+    [_logic] call EFUNC(common,updateEditableObjects);
 
     // Disable attributes for the logic
     _logic setVariable [QEGVAR(attributes,disabled), true, true];


### PR DESCRIPTION
**When merged this pull request will:**
- title, use case: sometimes you only want to edit a single object that is currently not editable and instead of going through the regular editable objects dialog with a small radius, this keybind provides a quick way to make the object editable (or not) by hovering over it
- Add `updateEditableObjects` objects common function
    - Replaces the old `addObjects`/`removeObjects` common events
    - Consolidates editable object updating in the code base to a single function