### PR TITLE
Improve Watch Cursor and Watch Curator Camera keybinds

### DIFF
--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -17,6 +17,7 @@ PREP(fireArtillery);
 PREP(fireVLS);
 PREP(fireWeapon);
 PREP(forceFire);
+PREP(forceWatch);
 PREP(formatDegrees);
 PREP(getActiveTree);
 PREP(getAllTurrets);

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -143,6 +143,27 @@
     _unit doWatch _target;
 }] call CBA_fnc_addEventHandler;
 
+[QGVAR(doTarget), {
+    params ["_unit", "_target", ["_reveal", true]];
+
+    if (_reveal) then {
+        if (_unit isEqualType objNull) then {
+            _unit = [_unit];
+        };
+
+        {
+            _x reveal [_target, 4];
+        } forEach _unit;
+    };
+
+    _unit doTarget _target;
+}] call CBA_fnc_addEventHandler;
+
+[QGVAR(lockCameraTo), {
+    params ["_vehicle", "_target", "_turretPath", "_temporary"];
+    _vehicle lockCameraTo [_target, _turretPath, _temporary];
+}] call CBA_fnc_addEventHandler;
+
 [QGVAR(enableGunLights), {
     params ["_unit", "_mode"];
     _unit enableGunLights _mode;

--- a/addons/common/functions/fnc_forceWatch.sqf
+++ b/addons/common/functions/fnc_forceWatch.sqf
@@ -1,0 +1,52 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Makes the given unit watch the specified target.
+ *
+ * Arguments:
+ * 0: Unit <OBJECT>
+ * 1: Target <OBJECT|ARRAY> (default: objNull)
+ *   - When given objNull, the unit stops watching its current target.
+ *   - Positions must be in AGL format.
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [_unit, _target] call zen_common_fnc_forceWatch
+ *
+ * Public: No
+ */
+
+params [["_unit", objNull, [objNull]], ["_target", objNull, [objNull, []], 3]];
+
+[QGVAR(doWatch), [[_unit, gunner _unit], _target], _unit] call CBA_fnc_targetEvent;
+
+// If an object is given, make the unit target the object in addition to watching it
+if (_target isEqualType objNull && {!isNull _target}) then {
+    [QGVAR(doTarget), [[_unit, gunner _unit], _target], _unit] call CBA_fnc_targetEvent;
+};
+
+// Make vehicles or units in vehicles watch target by locking their turret cameras onto it
+private _vehicle = vehicle _unit;
+
+if (
+    _unit isNotEqualTo _vehicle
+    || {_unit isKindOf "LandVehicle"}
+    || {_unit isKindOf "Air"}
+    || {_unit isKindOf "Ship"}
+) then {
+    private _turretPaths = if (_unit isEqualTo _vehicle) then {
+        _vehicle call FUNC(getAllTurrets)
+    } else {
+        [_vehicle unitTurret _unit]
+    };
+
+    if (_target isEqualType []) then {
+        _target = AGLToASL _target;
+    };
+
+    {
+        [QGVAR(lockCameraTo), [_vehicle, _target, _x, false], _vehicle, _x] call CBA_fnc_turretEvent;
+    } forEach _turretPaths;
+};

--- a/addons/editor/initKeybinds.sqf
+++ b/addons/editor/initKeybinds.sqf
@@ -146,7 +146,7 @@
                 // Cancel if target is self
                 private _isSelf = _x isEqualTo _target;
                 private _target = [_target, objNull] select _isSelf;
-                [QEGVAR(common,doWatch), [[_x, gunner _x], _target], _x] call CBA_fnc_targetEvent;
+                [_x, _target] call EFUNC(common,forceWatch);
                 if (_isSelf) then {continue};
 
                 [[
@@ -166,7 +166,7 @@
 
         {
             if (!isNull group _x && {!isPlayer _x}) then {
-                [QEGVAR(common,doWatch), [_x, _position], _x] call CBA_fnc_targetEvent;
+                [_x, _position] call EFUNC(common,forceWatch);
 
                 [[
                     ["ICON", [_position, "\a3\ui_f\data\igui\cfg\simpletasks\types\scout_ca.paa"]],


### PR DESCRIPTION
**When merged this pull request will:**
- title, locks vehicle turret cameras to the target to make the watch command have better targeting
- Also use `doTarget` when the target is given as an object (instead of position) - makes infantry raise their weapons without needing to be in combat mode
