### PR TITLE
Add Toggle Laser keybind

### DIFF
--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -68,6 +68,7 @@ PREP(setLampState);
 PREP(setMagazineAmmo);
 PREP(setTurretAmmo);
 PREP(setVehicleAmmo);
+PREP(setVehicleLaserState);
 PREP(showMessage);
 PREP(spawnLargeObject);
 PREP(teleportIntoVehicle);

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -351,6 +351,7 @@
 [QGVAR(setLampState), LINKFUNC(setLampState)] call CBA_fnc_addEventHandler;
 [QGVAR(setMagazineAmmo), LINKFUNC(setMagazineAmmo)] call CBA_fnc_addEventHandler;
 [QGVAR(setTurretAmmo), LINKFUNC(setTurretAmmo)] call CBA_fnc_addEventHandler;
+[QGVAR(setVehicleLaserState), LINKFUNC(setVehicleLaserState)] call CBA_fnc_addEventHandler;
 [QGVAR(showMessage), LINKFUNC(showMessage)] call CBA_fnc_addEventHandler;
 
 if (isServer) then {

--- a/addons/common/functions/fnc_setVehicleLaserState.sqf
+++ b/addons/common/functions/fnc_setVehicleLaserState.sqf
@@ -1,0 +1,46 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Sets the state (on/off) of the given vehicle turret's laser weapon.
+ *
+ * Arguments:
+ * 0: Vehicle <OBJECT>
+ * 1: State <BOOL> (default: nil)
+ *   - Toggles the laser's state when unspecified.
+ * 2: Turret Path <ARRAY> (default: [0])
+ *   - The primary gunner turret is used by default.
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [_vehicle, true] call zen_common_fnc_setVehicleLaserState
+ *
+ * Public: No
+ */
+
+params [["_vehicle", objNull, [objNull]], ["_state", nil, [true]], ["_turretPath", [0], [[]]]];
+
+if (!local _vehicle) exitWith {
+    [QGVAR(setVehicleLaserState), _this, _vehicle] call CBA_fnc_targetEvent;
+};
+
+// Exit if the laser is already turned on/off and we are not toggling it
+if (!isNil "_state" && {_vehicle isLaserOn _turretPath isEqualTo _state}) exitWith {};
+
+// Find the correct magazine id and owner and force the laser weapon to fire
+{
+    _x params ["_xMagazine", "_xTurretPath", "_xAmmoCount", "_id", "_owner"];
+
+    if (
+        _turretPath isEqualTo _xTurretPath
+        && {_xAmmoCount > 0}
+        && {
+            private _ammo = getText (configFile >> "CfgMagazines" >> _xMagazine >> "ammo");
+            private _ammoSimulation = getText (configFile >> "CfgAmmo" >> _ammo >> "simulation");
+            _ammoSimulation == "laserDesignate"
+        }
+    ) exitWith {
+        _vehicle action ["UseMagazine", _vehicle, _vehicle turretUnit _turretPath, _owner, _id];
+    };
+} forEach magazinesAllTurrets _vehicle;

--- a/addons/editor/initKeybinds.sqf
+++ b/addons/editor/initKeybinds.sqf
@@ -190,6 +190,18 @@
     [QEGVAR(common,forceFire), [[], CBA_clientID]] call CBA_fnc_globalEvent;
 }, [0, [false, false, false]]] call CBA_fnc_addKeybind; // Default: Unbound
 
+[[ELSTRING(main,DisplayName), LSTRING(AIControl)], QGVAR(toggleLaser), [LSTRING(ToggleLaser), LSTRING(ToggleLaser_Description)], {
+    if (!isNull curatorCamera && {!GETMVAR(RscDisplayCurator_search,false)}) then {
+        {
+            if (!isNull group _x && {!isPlayer _x}) then {
+                [_x] call EFUNC(common,setVehicleLaserState);
+            };
+        } forEach SELECTED_OBJECTS;
+
+        true // handled
+    };
+}, {}, [0, [false, false, false]]] call CBA_fnc_addKeybind; // Default: Unbound
+
 [[ELSTRING(main,DisplayName), LSTRING(AIControl)], QGVAR(moveToCursor), [LSTRING(MoveToCursor), LSTRING(MoveToCursor_Description)], {
     if (!isNull curatorCamera && {!GETMVAR(RscDisplayCurator_search,false)}) then {
         private _position = ASLToAGL ([] call EFUNC(common,getPosFromScreen));

--- a/addons/editor/stringtable.xml
+++ b/addons/editor/stringtable.xml
@@ -393,6 +393,12 @@
         <Key ID="STR_ZEN_Editor_ForceFire_Description">
             <English>Makes selected AI units fire their current weapon while the key is held down. Vehicles will fire their first available turret with a weapon.</English>
         </Key>
+        <Key ID="STR_ZEN_Editor_ToggleLaser">
+            <English>Toggle Laser</English>
+        </Key>
+        <Key ID="STR_ZEN_Editor_ToggleLaser_Description">
+            <English>Makes selected AI units (vehicles) toggle their turret laser weapons on or off.</English>
+        </Key>
         <Key ID="STR_ZEN_Editor_MoveToCursor">
             <English>Move To Cursor</English>
         </Key>

--- a/addons/editor/stringtable.xml
+++ b/addons/editor/stringtable.xml
@@ -397,7 +397,7 @@
             <English>Toggle Laser</English>
         </Key>
         <Key ID="STR_ZEN_Editor_ToggleLaser_Description">
-            <English>Makes selected AI units (vehicles) toggle their turret laser weapons on or off.</English>
+            <English>Makes selected AI units in vehicles toggle their turret laser weapons on or off.</English>
         </Key>
         <Key ID="STR_ZEN_Editor_MoveToCursor">
             <English>Move To Cursor</English>


### PR DESCRIPTION
**When merged this pull request will:**
- title, pairs nicely with the force fire keybind
- Useful because we don't list laser weapons in the context menu action for switching vehicle weapons and this would be much faster than switching back and forth between laser and missiles (for example)