### PR TITLE
Fix placement preview activating modules in recent tree

### DIFF
--- a/addons/placement/XEH_postInit.sqf
+++ b/addons/placement/XEH_postInit.sqf
@@ -23,7 +23,7 @@
 
         private _objectType = _ctrlTreeRecent tvData _selectedPath;
 
-        if (!isClass (configFile >> "CfgVehicles" >> _objectType)) then {
+        if (!isClass (configFile >> "CfgVehicles" >> _objectType) || {_objectType isKindOf "Logic"}) then {
             _objectType = "";
         };
 

--- a/addons/placement/functions/fnc_handleTreeChange.sqf
+++ b/addons/placement/functions/fnc_handleTreeChange.sqf
@@ -26,7 +26,7 @@ private _objectType = if (_mode in [0, 4] && {call EFUNC(common,isPlacementActiv
     private _ctrlTree = call EFUNC(common,getActiveTree);
     private _data = _ctrlTree tvData tvCurSel _ctrlTree;
 
-    if (_mode == 4 && {!isClass (configFile >> "CfgVehicles" >> _data)}) then {
+    if (_mode == 4 && {!isClass (configFile >> "CfgVehicles" >> _data) || {_data isKindOf "Logic"}}) then {
         _data = "";
     };
 


### PR DESCRIPTION
**When merged this pull request will:**
- title, because placement preview creates a local object of the selected type, selecting a module in the recent tree would bring up its dialog (instead we just ignore modules)