### PR TITLE
Set negative draw priority for Building Markers

### DIFF
--- a/addons/building_markers/functions/fnc_set.sqf
+++ b/addons/building_markers/functions/fnc_set.sqf
@@ -61,6 +61,8 @@ if (_set) then {
     _marker setMarkerDir getDir _object;
     _object setVariable [QGVAR(marker), _marker, true];
 
+    [QEGVAR(common,setMarkerDrawPriority), [_marker, -1]] call CBA_fnc_globalEvent;
+
     // Delete marker when the object is deleted
     private _eventID = _object addEventHandler ["Deleted", {
         params ["_object"];

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -304,6 +304,11 @@
     _object setObjectScale _scale;
 }] call CBA_fnc_addEventHandler;
 
+[QGVAR(setMarkerDrawPriority), {
+    params ["_markerName", "_priority"];
+    _markerName setMarkerDrawPriority _priority;
+}] call CBA_fnc_addEventHandler;
+
 [QGVAR(setVehicleRadar), {
     params ["_vehicle", "_mode"];
     _vehicle setVehicleRadar _mode;


### PR DESCRIPTION
**When merged this pull request will:**
- Prevent Building Markers from covering player placed markers
- Add setMarkerDrawPriority event
- Call event after building marker creation
- ![image](https://user-images.githubusercontent.com/11483210/233816111-498d2d59-537f-4322-8b48-d312cb74dc54.png)
