### PR TITLE
Fix typo for garrisoned flag

### DIFF
--- a/addons/ai/functions/fnc_unGarrison.sqf
+++ b/addons/ai/functions/fnc_unGarrison.sqf
@@ -33,7 +33,7 @@
             group _unit enableAttack true;
         };
 
-        _unit setVariable [QGVAR(garrisonned), false, true];
+        _unit setVariable [QGVAR(garrisoned), false, true];
         
         // End fix for rotating garrisoned units
         _unit doWatch objNull;


### PR DESCRIPTION
**When merged this pull request will:**
- Fix a typo that results in the garrisoned flag not be set false when ungarrisoned
- This causes issues with mods such a ZHC that check this flag.
