### PR TITLE
Use profile name for Ping Zeus keybind

### DIFF
--- a/addons/editor/functions/fnc_pingCurators.sqf
+++ b/addons/editor/functions/fnc_pingCurators.sqf
@@ -7,6 +7,7 @@
  * 0: Curator <OBJECT>
  * 1: Ping Target <OBJECT|ARRAY>
  *   - Positions must be in AGL format.
+ * 2: Curator's Name <STRING> (default: "")
  *
  * Return Value:
  * None
@@ -32,7 +33,7 @@
 
 if (isNull curatorCamera) exitWith {};
 
-params ["_curator", "_target"];
+params ["_curator", "_target", ["_name", ""]];
 
 GVAR(pingTarget) = _target;
 
@@ -41,9 +42,7 @@ if (isNil QGVAR(pingDrawMap)) then {
     GVAR(pingDrawMap) = createHashMap;
 };
 
-private _hash = hashValue _curator;
-private _name = name getAssignedCuratorUnit _curator;
-GVAR(pingDrawMap) set [_hash, [_target, _name, CBA_missionTime]];
+GVAR(pingDrawMap) set [hashValue _curator, [_target, _name, CBA_missionTime]];
 
 if (isNil QGVAR(pingDraw3D)) then {
     GVAR(pingDraw3D) = addMissionEventHandler ["Draw3D", {

--- a/addons/editor/initKeybinds.sqf
+++ b/addons/editor/initKeybinds.sqf
@@ -128,7 +128,7 @@
         };
 
         private _curator = getAssignedCuratorLogic player;
-        [QGVAR(pingCurators), [_curator, _target], allCurators] call CBA_fnc_targetEvent;
+        [QGVAR(pingCurators), [_curator, _target, profileName], allCurators] call CBA_fnc_targetEvent;
 
         true // handled
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Use `profileName` to get the name to display for Zeus pings
- Not sure why but, in testing, `name` would sometimes display "Error: No vehicle" (this should avoid that)