### PR TITLE
Added: Server events for getting the code string, for logging in missions

### DIFF
--- a/addons/attributes/initAttributes.sqf
+++ b/addons/attributes/initAttributes.sqf
@@ -375,6 +375,7 @@
     [QGVAR(objectExecHistory), QGVAR(objectExecMode), LSTRING(ExecObject_Tooltip), 20, 1000],
     {
         _value params ["_code", "_mode"];
+        [QGVAR(objectExecCode), [_code, _mode, _entity]] call CBA_fnc_serverEvent;
 
         _code = compile _code;
 
@@ -534,6 +535,7 @@
     [QGVAR(groupExecHistory), QGVAR(groupExecMode), LSTRING(ExecGroup_Tooltip), 20, 1000],
     {
         _value params ["_code", "_mode"];
+        [QGVAR(groupExecCode), [_code, _mode, _entity]] call CBA_fnc_serverEvent;
 
         _code = compile _code;
 

--- a/addons/attributes/initAttributes.sqf
+++ b/addons/attributes/initAttributes.sqf
@@ -375,7 +375,7 @@
     [QGVAR(objectExecHistory), QGVAR(objectExecMode), LSTRING(ExecObject_Tooltip), 20, 1000],
     {
         _value params ["_code", "_mode"];
-        [QGVAR(objectExecCode), [_code, _mode, _entity]] call CBA_fnc_serverEvent;
+        [QGVAR(objectExecCode), [_code, _mode, _entity]] call CBA_fnc_localEvent;
 
         _code = compile _code;
 
@@ -535,7 +535,7 @@
     [QGVAR(groupExecHistory), QGVAR(groupExecMode), LSTRING(ExecGroup_Tooltip), 20, 1000],
     {
         _value params ["_code", "_mode"];
-        [QGVAR(groupExecCode), [_code, _mode, _entity]] call CBA_fnc_serverEvent;
+        [QGVAR(groupExecCode), [_code, _mode, _entity]] call CBA_fnc_localEvent;
 
         _code = compile _code;
 

--- a/addons/modules/functions/fnc_gui_executeCode.sqf
+++ b/addons/modules/functions/fnc_gui_executeCode.sqf
@@ -83,6 +83,8 @@ private _fnc_onConfirm = {
 
     profileNamespace setVariable [VAR_HISTORY, _history];
 
+    [QGVAR(guiExecCode), [_code, _mode, _entity]] call CBA_fnc_serverEvent;
+
     _code = compile _code;
 
     switch (_mode) do {

--- a/addons/modules/functions/fnc_gui_executeCode.sqf
+++ b/addons/modules/functions/fnc_gui_executeCode.sqf
@@ -83,7 +83,7 @@ private _fnc_onConfirm = {
 
     profileNamespace setVariable [VAR_HISTORY, _history];
 
-    [QGVAR(guiExecCode), [_code, _mode, _entity]] call CBA_fnc_serverEvent;
+    [QGVAR(guiExecCode), [_code, _mode, _args]] call CBA_fnc_serverEvent;
 
     _code = compile _code;
 

--- a/addons/modules/functions/fnc_gui_executeCode.sqf
+++ b/addons/modules/functions/fnc_gui_executeCode.sqf
@@ -83,7 +83,7 @@ private _fnc_onConfirm = {
 
     profileNamespace setVariable [VAR_HISTORY, _history];
 
-    [QGVAR(guiExecCode), [_code, _mode, _args]] call CBA_fnc_serverEvent;
+    [QGVAR(guiExecCode), [_code, _mode, _args]] call CBA_fnc_localEvent;
 
     _code = compile _code;
 


### PR DESCRIPTION
**When merged this pull request will:**
Add a server event that mods and mission makers can listen to. This was done in the case of wanting to log what code was being executed on objects, players, groups... etc. In our case for Antistasi, we want to be able to look at our log file to see if someone is executing code through Zen. 



- objectExecCode event:
params:
_code - string of code to execute
_mode - code execution mode
_entity - object entity that refers to _this 

- groupExecCode event:
params:
_code - string of code to execute
_mode - code execution mode
_entity - group entity that refers to _this 

- guiExecCode
_code - string of code to execute
_mode - code execution mode
_args - arguments passed to the code
