### PR TITLE
Fix HEMTT launch warning and post release hook

### DIFF
--- a/.hemtt/hooks/post_release/01_rename_zip.rhai
+++ b/.hemtt/hooks/post_release/01_rename_zip.rhai
@@ -1,7 +1,7 @@
 let releases = HEMTT_RFS.join("releases");
 
 let src = releases.join(HEMTT.project().prefix() + "-" + HEMTT.project().version().to_string() + ".zip");
-let dst = releases.join(HEMTT.project().name().to_lower() + "_" + HEMTT.project().version().to_string_short() + ".zip");
+let dst = releases.join(HEMTT.project().prefix().to_lower() + "_" + HEMTT.project().version().to_string_short() + ".zip");
 
 print("Moving zip to " + dst);
 if !src.move(dst) {

--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -17,7 +17,7 @@ include = [
 [version]
 git_hash = 0
 
-[hemtt.launch]
+[hemtt.launch.default]
 workshop = [
     "450814997", # CBA_A3
 ]


### PR DESCRIPTION
**When merged this pull request will:**
- title, release zip archives were not named correctly
