### PR TITLE
fixed using undefined variable for sidechange instead of group

### DIFF
--- a/addons/common/functions/fnc_changeGroupSide.sqf
+++ b/addons/common/functions/fnc_changeGroupSide.sqf
@@ -30,7 +30,7 @@ if (allGroups findIf {side _x isEqualTo _side && {groupId _x isEqualTo _groupId}
     _newGroup setGroupIdGlobal [_groupId];
 };
 
-private _units = units _unit;
+private _units = units _group;
 
 // Preserve assigned team for each unit
 // Teams need to be gotten before removing units from group


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes using undefined ``_unit`` variable in #763 instead of ``_group``. 

Side change logic worked when tested in editor after this change. 
