### PR TITLE
Show 3DEN comments in Zeus

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -50,6 +50,7 @@ PlayerBot
 Ryan180602
 shukari
 SilentSpike
+Timi007
 Toinane
 Tuupertunut
 veteran29

--- a/addons/comments/$PBOPREFIX$
+++ b/addons/comments/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\zen\addons\comments

--- a/addons/comments/Cfg3DEN.hpp
+++ b/addons/comments/Cfg3DEN.hpp
@@ -1,0 +1,32 @@
+class Cfg3DEN {
+    class Attributes {
+        class Default;
+        class GVAR(HiddenAttribute): Default {
+            onLoad = QUOTE((ctrlParentControlsGroup ctrlParentControlsGroup (_this select 0)) ctrlShow false);
+        };
+    };
+
+    class Mission {
+        class Scenario {
+            class AttributeCategories {
+                class PREFIX {
+                    collapsed = 1;
+                    displayName = ECSTRING(main,DisplayName);
+
+                    class Attributes {
+                        class GVAR(3DENComments) {
+                            property = QGVAR(3DENComments);
+                            value = 0;
+                            control = QGVAR(HiddenAttribute);
+                            displayName = CSTRING(DisplayName);
+                            tooltip = "";
+                            defaultValue = "[]";
+                            expression = "";
+                            wikiType = "[[Array]]";
+                        };
+                    };
+                };
+            };
+        };
+    };
+};

--- a/addons/comments/CfgEventHandlers.hpp
+++ b/addons/comments/CfgEventHandlers.hpp
@@ -1,0 +1,17 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_preStart));
+    };
+};
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_preInit));
+    };
+};
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
+    };
+};

--- a/addons/comments/XEH_PREP.hpp
+++ b/addons/comments/XEH_PREP.hpp
@@ -1,0 +1,2 @@
+PREP(addDrawEventHandler);
+PREP(save3DENComments);

--- a/addons/comments/XEH_postInit.sqf
+++ b/addons/comments/XEH_postInit.sqf
@@ -1,0 +1,9 @@
+#include "script_component.hpp"
+
+if (!hasInterface) exitWith {};
+
+GVAR(draw3DAdded) = false;
+["zen_curatorDisplayLoaded", LINKFUNC(addDrawEventHandler)] call CBA_fnc_addEventHandler;
+
+GVAR(3DENComments) = getMissionConfigValue [QGVAR(3DENComments), []];
+TRACE_1("Loaded 3DEN Comments from mission",GVAR(3DENComments));

--- a/addons/comments/XEH_preInit.sqf
+++ b/addons/comments/XEH_preInit.sqf
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+PREP_RECOMPILE_START;
+#include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
+
+#include "initSettings.inc.sqf"
+
+// For 3DEN comments in Zeus
+if (is3DEN) then {
+    // Arguments are for debugging
+    add3DENEventHandler ["OnMissionSave", {["OnMissionSave"] call FUNC(save3DENComments)}];
+    add3DENEventHandler ["OnMissionAutosave", {["OnMissionAutosave"] call FUNC(save3DENComments)}];
+};
+
+ADDON = true;

--- a/addons/comments/XEH_preStart.sqf
+++ b/addons/comments/XEH_preStart.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+#include "XEH_PREP.hpp"

--- a/addons/comments/config.cpp
+++ b/addons/comments/config.cpp
@@ -1,0 +1,20 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"zen_common"};
+        author = ECSTRING(main,Author);
+        authors[] = {"Timi007"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+PRELOAD_ADDONS;
+
+#include "CfgEventHandlers.hpp"
+#include "Cfg3DEN.hpp"

--- a/addons/comments/functions/fnc_addDrawEventHandler.sqf
+++ b/addons/comments/functions/fnc_addDrawEventHandler.sqf
@@ -1,0 +1,109 @@
+#include "script_component.hpp"
+/*
+ * Author: Timi007
+ * Function triggered every time the Zeus/Curator display is opened.
+ * Adds the draw event handlers to display 3DEN comments in 3D and on the map.
+ *
+ * Arguments:
+ * 0: Zeus Display <DISPLAY>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [_display] call zen_comments_fnc_addDrawEventHandler
+ *
+ * Public: No
+ */
+
+params ["_display"];
+TRACE_1("Zeus display opened",_display);
+
+if (!GVAR(enable3DENComments)) exitWith {};
+
+if (!GVAR(draw3DAdded)) then {
+    LOG("Adding 3DENComments Draw3D.");
+    addMissionEventHandler ["Draw3D", {
+        if (!GVAR(enable3DENComments)) exitWith {
+            removeMissionEventHandler [_thisEvent, _thisEventHandler];
+            GVAR(draw3DAdded) = false;
+            LOG("Removed 3DENComments Draw3D.");
+        };
+
+        // Not in Zeus, in pause menu or HUD is hidden
+        if (
+            isNull (findDisplay IDD_RSCDISPLAYCURATOR) ||
+            {!isNull (findDisplay IDD_INTERRUPT)} ||
+            {call EFUNC(common,isInScreenshotMode)}
+        ) exitWith {};
+
+        private _camPosASL = getPosASLVisual curatorCamera;
+        private _color = GVAR(3DENCommentsColor); // Copy global var for slightly better performance
+
+        {
+            _x params ["_id", "_name", "_description", "_posASL"];
+
+            private _d = _posASL distance _camPosASL;
+            private _scale = linearConversion [300, 750, _d, 0.8, 0, true]; // 300m => 0.8, 750m => 0
+            private _posAGL = ASLToAGL _posASL;
+
+            // Don't draw icon if it's too small or outside screen
+            if (_scale < 0.01 || {(curatorCamera worldToScreen _posAGL) isEqualTo []}) then {
+                continue;
+            };
+
+            drawIcon3D [
+                "a3\3den\Data\Cfg3DEN\Comment\texture_ca.paa",
+                _color,
+                _posAGL,
+                _scale,             // Width
+                _scale,             // Height
+                0,                  // Angle
+                _name,              // Text
+                1,                  // Shadow
+                -1,                 // Text Size
+                "RobotoCondensed"   // Font
+            ];
+
+            // Draw ground-icon connection line only for icons higher than 0.5 m
+            if ((_posAGL select 2) > 0.5) then {
+                drawLine3D [_posAGL, [_posAGL select 0, _posAGL select 1, 0], _color];
+            };
+        } count GVAR(3DENComments); // Use count for slightly better performance
+    }];
+};
+
+// MapDraw EH needs to be added every time the Zeus display is opened.
+LOG("Adding 3DENComments map draw.");
+(_display displayCtrl IDC_RSCDISPLAYCURATOR_MAINMAP) ctrlAddEventHandler ["Draw", {
+    params ["_mapCtrl"];
+
+    if (!GVAR(enable3DENComments)) exitWith {
+        _mapCtrl ctrlRemoveEventHandler [_thisEvent, _thisEventHandler];
+        LOG("Removed 3DENComments map draw.");
+    };
+
+    // Draw is only called when map is open
+    if (call EFUNC(common,isInScreenshotMode)) exitWith {}; // HUD is hidden
+
+    private _color = GVAR(3DENCommentsColor); // Copy global var for slightly better performance
+
+    {
+        _x params ["_id", "_name", "_description", "_posASL"];
+
+        _mapCtrl drawIcon [
+            "a3\3den\Data\Cfg3DEN\Comment\texture_ca.paa",
+            _color,
+            _posASL,
+            24,                 // Width
+            24,                 // Height
+            0,                  // Angle
+            _name,              // Text
+            1,                  // Shadow
+            -1,                 // Text Size
+            "RobotoCondensed"   // Font
+        ];
+    } count GVAR(3DENComments); // Use count for slightly better performance
+}];
+
+GVAR(draw3DAdded) = true;

--- a/addons/comments/functions/fnc_addDrawEventHandler.sqf
+++ b/addons/comments/functions/fnc_addDrawEventHandler.sqf
@@ -44,7 +44,7 @@ if (!GVAR(draw3DAdded)) then {
             _x params ["_id", "_name", "_description", "_posASL"];
 
             private _d = _posASL distance _camPosASL;
-            private _scale = linearConversion [300, 750, _d, 0.8, 0, true]; // 300m => 0.8, 750m => 0
+            private _scale = linearConversion [300, 750, _d, 0.65, 0, true]; // 300m => 0.65, 750m => 0
             private _posAGL = ASLToAGL _posASL;
 
             // Don't draw icon if it's too small or outside screen
@@ -67,7 +67,8 @@ if (!GVAR(draw3DAdded)) then {
 
             // Draw ground-icon connection line only for icons higher than 0.5 m
             if ((_posAGL select 2) > 0.5) then {
-                drawLine3D [_posAGL, [_posAGL select 0, _posAGL select 1, 0], _color];
+                // Hide line behind icon
+                drawLine3D [_posAGL vectorAdd [0, 0, -0.05], [_posAGL select 0, _posAGL select 1, 0], _color];
             };
         } count GVAR(3DENComments); // Use count for slightly better performance
     }];

--- a/addons/comments/functions/fnc_save3DENComments.sqf
+++ b/addons/comments/functions/fnc_save3DENComments.sqf
@@ -1,0 +1,44 @@
+#include "script_component.hpp"
+/*
+ * Author: Timi007
+ * Function called when 3DEN save event is triggered.
+ * Handles saving comments into scenario space for later use.
+ *
+ * Arguments:
+ * 0: Event that triggered this function (for debug purposes) <STRING>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * call zen_comments_fnc_save3DENComments
+ *
+ * Public: No
+ */
+
+params [["_event", "", [""]]];
+
+if (!is3DEN) exitWith {};
+
+private _comments = [];
+{
+    private _id = _x;
+    // all3DENEntities includes always includes this id, ignore
+    if (_id isEqualTo -999) then {
+        continue;
+    };
+
+    private _name = (_id get3DENAttribute "name") select 0;
+    private _description = (_id get3DENAttribute "description") select 0;
+    private _positionASL = (_id get3DENAttribute "position") select 0;
+
+    // Ignore comments with special ignore directive in the description/tooltip
+    if (IGNORE_3DEN_COMMENT_STRING in _description) then {
+        continue;
+    };
+
+    _comments pushBack [_id, _name, _description, _positionASL];
+} forEach (all3DENEntities param [7, []]);
+
+set3DENMissionAttributes [["Scenario", QGVAR(3DENComments), _comments]];
+TRACE_2("Saved 3DEN comments",_event,_comments);

--- a/addons/comments/functions/fnc_save3DENComments.sqf
+++ b/addons/comments/functions/fnc_save3DENComments.sqf
@@ -23,7 +23,7 @@ if (!is3DEN) exitWith {};
 private _comments = [];
 {
     private _id = _x;
-    // all3DENEntities includes always includes this id, ignore
+    // all3DENEntities always includes this id, ignore it
     if (_id isEqualTo -999) then {
         continue;
     };

--- a/addons/comments/functions/script_component.hpp
+++ b/addons/comments/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "\x\zen\addons\comments\script_component.hpp"

--- a/addons/comments/initSettings.inc.sqf
+++ b/addons/comments/initSettings.inc.sqf
@@ -1,0 +1,17 @@
+[
+    QGVAR(enable3DENComments),
+    "CHECKBOX",
+    [LLSTRING(3DENComments), LLSTRING(3DENComments_Description)],
+    [ELSTRING(main,DisplayName), LSTRING(DisplayName)],
+    true,
+    0
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(3DENCommentsColor),
+    "COLOR",
+    [LLSTRING(3DENCommentsColor), LLSTRING(3DENCommentsColor_Description)],
+    [ELSTRING(main,DisplayName), LSTRING(DisplayName)],
+    [0, 1, 0.75, 1],
+    0
+] call CBA_fnc_addSetting;

--- a/addons/comments/script_component.hpp
+++ b/addons/comments/script_component.hpp
@@ -1,0 +1,22 @@
+#define COMPONENT comments
+#define COMPONENT_BEAUTIFIED Comments
+#include "\x\zen\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_COMMENTS
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_COMMENTS
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_COMMENTS
+#endif
+
+#include "\x\zen\addons\main\script_macros.hpp"
+
+#include "\x\zen\addons\common\defineResinclDesign.inc"
+
+// Ignore comments that include following string in the description/tooltip
+#define IGNORE_3DEN_COMMENT_STRING "#ZEN_IGNORE#"

--- a/addons/comments/stringtable.xml
+++ b/addons/comments/stringtable.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="ZEN">
+    <Package name="Comments">
+        <Key ID="STR_ZEN_Comments_DisplayName">
+            <English>Comments</English>
+            <German>Kommentare</German>
+        </Key>
+    </Package>
+    <Package name="3DENComments">
+        <Key ID="STR_ZEN_Comments_3DENComments">
+            <English>Show 3DEN comments in Zeus</English>
+            <German>Zeige 3DEN-Kommentare im Zeus</German>
+        </Key>
+        <Key ID="STR_ZEN_Comments_3DENComments_Description">
+            <English>Show 3DEN comments in Zeus.</English>
+            <German>Zeige 3DEN-Kommentare im Zeus an.</German>
+        </Key>
+        <Key ID="STR_ZEN_Comments_3DENCommentsColor">
+            <English>3DEN comments color</English>
+            <German>Farbe der 3DEN-Kommentare</German>
+        </Key>
+        <Key ID="STR_ZEN_Comments_3DENCommentsColor_Description">
+            <English>Color of 3DEN Kommentare in Zeus.</English>
+            <German>Farbe der 3DEN-Kommentare im Zeus.</German>
+        </Key>
+    </Package>
+</Project>


### PR DESCRIPTION
Hello everyone! I would like to donate a feature from one of my mods. 

**When merged this pull request will:**
- Shows 3DEN comments in Zeus 3D and on the map

### How it works
All comments get stored in as a scenario attribute that is available during mission runtime. Currently, only the comment name is displayed and the description/tooltip is ignored. For it to work, the mission must be saved before preview. You can also hide an 3DEN comment by including the directive `#ZEN_IGNORE#` in the description/tooltip of the comment.

![zen_3den_comments_zeus](https://github.com/user-attachments/assets/d208d980-781a-4b8f-9080-509658a77fc1)

### TODO

- [ ] Documentation

I also plan on adding the ability to create comments as Zeus during mission runtime. I think a module and context menu action would be nice. How do you handle internal dependencies? Should the module and action be implemented in their respective addons `modules` and `context_actions`? Or should they be implemented in this addon and depend on `modules` and `context_menu` for the classes and API?

Furthermore, I cannot store the comments without saving (I thought I could do it with the new `OnBeforeMissionPreview` event, but it does not work for me). And displaying tooltips on 3D icons is also not possible. So if anyone has some idea on how to solve these problems, I would be grateful.