### PR TITLE
Fix Attach Flag module not supporting all flag pole types

### DIFF
--- a/addons/modules/functions/fnc_moduleAttachFlag.sqf
+++ b/addons/modules/functions/fnc_moduleAttachFlag.sqf
@@ -28,7 +28,7 @@ if !(alive _object) exitWith {
     [LSTRING(OnlyAlive)] call EFUNC(common,showMessage);
 };
 
-if !(_object isKindOf "AllVehicles" || {_object isKindOf "FlagCarrier"}) exitWith {
+if !(_object isKindOf "AllVehicles" || {_object isKindOf "FlagCarrierCore"}) exitWith {
     [LSTRING(OnlyVehiclesOrFlags)] call EFUNC(common,showMessage);
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- https://github.com/zen-mod/ZEN/pull/749 was made for PortableFlagPole_01_F (which was added in the 2.14 update) but it was not actually supported.
- This change allows the change to be applied to all flags based on FlagCarrierCore other than Flag Pole. (FlagChecked_F is also included)
