### PR TITLE
Dialog - Add sub-type `VECTOR:SIZE` & options to set min and max values

### DIFF
--- a/addons/dialog/functions/fnc_create.sqf
+++ b/addons/dialog/functions/fnc_create.sqf
@@ -238,7 +238,15 @@ private _fnc_verifyListEntries = {
         };
         case "VECTOR": {
             _defaultValue = [_valueInfo] param [0, [0, 0], [], [2, 3]];
-            _controlType = [QGVAR(Row_VectorXY), QGVAR(Row_VectorXYZ)] select (count _defaultValue > 2);
+
+            private _controlTypeStyle = [
+                [QGVAR(Row_VectorXY), QGVAR(Row_VectorXYZ)],
+                [QGVAR(Row_VectorAB), QGVAR(Row_VectorABC)]
+            ] select (_subType == "SIZE");
+            _controlType = _controlTypeStyle select (count _defaultValue > 2);
+
+            private _allowNegativeNumbers = _subType != "SIZE";
+            _settings append [_allowNegativeNumbers];
         };
     };
 

--- a/addons/dialog/functions/fnc_create.sqf
+++ b/addons/dialog/functions/fnc_create.sqf
@@ -246,6 +246,12 @@ private _fnc_verifyListEntries = {
             _controlType = _controlTypeStyle select (count _defaultValue > 2);
 
             private _allowNegativeNumbers = _subType != "SIZE";
+
+            // Don't set values below zero if negative numbers are forbidden
+            if (!_allowNegativeNumbers) then {
+                _defaultValue = _defaultValue apply {_x max 0};
+            };
+
             _settings append [_allowNegativeNumbers];
         };
     };

--- a/addons/dialog/functions/fnc_create.sqf
+++ b/addons/dialog/functions/fnc_create.sqf
@@ -255,6 +255,11 @@ private _fnc_verifyListEntries = {
             ] select (_subType == "SIZE");
             _controlType = _controlTypeStyle select (count _default > 2);
 
+            if (_subType == "SIZE" && {_min isEqualTo []}) then {
+                // SIZE subtype should only allow for positive values and zero by default
+                _min = _default apply {0};
+            };
+
             // Clip default values between min and max
             _defaultValue = +_default;
             if (_min isNotEqualTo []) then {

--- a/addons/dialog/functions/fnc_create.sqf
+++ b/addons/dialog/functions/fnc_create.sqf
@@ -237,22 +237,55 @@ private _fnc_verifyListEntries = {
             _settings append [_returnBool, _rows, _columns, _strings, _height, _isWide];
         };
         case "VECTOR": {
-            _defaultValue = [_valueInfo] param [0, [0, 0], [], [2, 3]];
+            // Backwards compatibility for old format
+            if ((_valueInfo select 0) isEqualType 0) then {
+                _valueInfo = [_valueInfo];
+            };
+
+            _valueInfo params [
+                ["_default", [0, 0], [], [2, 3]],
+                ["_min", [], [], [0, 2, 3]],
+                ["_max", [], [], [0, 2, 3]],
+                ["_onlyIntegers", false, [false]]
+            ];
 
             private _controlTypeStyle = [
                 [QGVAR(Row_VectorXY), QGVAR(Row_VectorXYZ)],
                 [QGVAR(Row_VectorAB), QGVAR(Row_VectorABC)]
             ] select (_subType == "SIZE");
-            _controlType = _controlTypeStyle select (count _defaultValue > 2);
+            _controlType = _controlTypeStyle select (count _default > 2);
 
-            private _allowNegativeNumbers = _subType != "SIZE";
+            // Clip default values between min and max
+            _defaultValue = +_default;
+            if (_min isNotEqualTo []) then {
+                if (count _min isNotEqualTo count _default) then {
+                    WARNING_2("Array for min vector values must have the same size as the default array or empty. Default: %1 / Min: %2",count _default,count _min);
+                    false breakOut "Main";
+                };
 
-            // Don't set values below zero if negative numbers are forbidden
-            if (!_allowNegativeNumbers) then {
-                _defaultValue = _defaultValue apply {_x max 0};
+                {
+                    private _iMin = _min select _forEachIndex;
+                    if (!isNil "_iMin") then {
+                        _defaultValue set [_forEachIndex, _x max _iMin];
+                    };
+                } forEach _defaultValue;
             };
 
-            _settings append [_allowNegativeNumbers];
+            if (_max isNotEqualTo []) then {
+                if (count _max isNotEqualTo count _default) then {
+                    WARNING_2("Array for max vector values must have the same size as the default array or empty. Default: %1 / Max: %2",count _default,count _max);
+                    false breakOut "Main";
+                };
+
+                {
+                    private _iMax = _max select _forEachIndex;
+                    if (!isNil "_iMax") then {
+                        _defaultValue set [_forEachIndex, _x min _iMax];
+                    };
+                } forEach _defaultValue;
+            };
+
+            _settings append [_min, _max, _onlyIntegers];
         };
     };
 

--- a/addons/dialog/functions/fnc_create.sqf
+++ b/addons/dialog/functions/fnc_create.sqf
@@ -238,7 +238,7 @@ private _fnc_verifyListEntries = {
         };
         case "VECTOR": {
             // Backwards compatibility for old format
-            if ((_valueInfo select 0) isEqualType 0) then {
+            if (_valueInfo select 0 isEqualType 0) then {
                 _valueInfo = [_valueInfo];
             };
 
@@ -253,6 +253,7 @@ private _fnc_verifyListEntries = {
                 [QGVAR(Row_VectorXY), QGVAR(Row_VectorXYZ)],
                 [QGVAR(Row_VectorAB), QGVAR(Row_VectorABC)]
             ] select (_subType == "SIZE");
+
             _controlType = _controlTypeStyle select (count _default > 2);
 
             if (_subType == "SIZE" && {_min isEqualTo []}) then {
@@ -262,6 +263,7 @@ private _fnc_verifyListEntries = {
 
             // Clip default values between min and max
             _defaultValue = +_default;
+
             if (_min isNotEqualTo []) then {
                 if (count _min isNotEqualTo count _default) then {
                     WARNING_2("Array for min vector values must have the same size as the default array or empty. Default: %1 / Min: %2",count _default,count _min);
@@ -270,6 +272,7 @@ private _fnc_verifyListEntries = {
 
                 {
                     private _iMin = _min select _forEachIndex;
+                    
                     if (!isNil "_iMin") then {
                         _defaultValue set [_forEachIndex, _x max _iMin];
                     };
@@ -284,6 +287,7 @@ private _fnc_verifyListEntries = {
 
                 {
                     private _iMax = _max select _forEachIndex;
+                    
                     if (!isNil "_iMax") then {
                         _defaultValue set [_forEachIndex, _x min _iMax];
                     };

--- a/addons/dialog/functions/fnc_create.sqf
+++ b/addons/dialog/functions/fnc_create.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /*
- * Author: mharis001
+ * Author: mharis001, Timi007
  * Creates a dialog with the given rows of content.
  *
  * Arguments:

--- a/addons/dialog/functions/fnc_gui_vector.sqf
+++ b/addons/dialog/functions/fnc_gui_vector.sqf
@@ -1,19 +1,21 @@
 #include "script_component.hpp"
 /*
- * Author: mharis001
+ * Author: mharis001, Timi007
  * Initializes the VECTOR content control.
  *
  * Arguments:
  * 0: Controls Group <CONTROL>
  * 1: Default Value <ARRAY>
  * 2: Settings <ARRAY>
- *     0: Allow entering negative numbers <BOOL>
+ *     0: Minimum values for each vector component <ARRAY>
+ *     1: Maximum values for each vector component <ARRAY>
+ *     2: Only allow integers <BOOL>
  *
  * Return Value:
  * None
  *
  * Example:
- * [CONTROL, [0, 0, 0]] call zen_dialog_fnc_gui_vector
+ * [CONTROL, [0, 0, 0], [[-1, 0, nil], [nil, nil, 50], false]] call zen_dialog_fnc_gui_vector
  *
  * Public: No
  */

--- a/addons/dialog/functions/fnc_gui_vector.sqf
+++ b/addons/dialog/functions/fnc_gui_vector.sqf
@@ -7,9 +7,9 @@
  * 0: Controls Group <CONTROL>
  * 1: Default Value <ARRAY>
  * 2: Settings <ARRAY>
- *     0: Minimum values for each vector component <ARRAY>
- *     1: Maximum values for each vector component <ARRAY>
- *     2: Only allow integers <BOOL>
+ *   0: Minimum Values <ARRAY>
+ *   1: Maximum Values <ARRAY>
+ *   2: Only Allow Integers <BOOL>
  *
  * Return Value:
  * None
@@ -28,10 +28,13 @@ private _fnc_textChanged = {
     params ["_ctrlEdit"];
 
     private _filter = toArray "0123456789";
+    
     if !(_ctrlEdit getVariable [QGVAR(onlyIntegers), false]) then {
         _filter pushBack (toArray "." select 0);
     };
+    
     private _min = _ctrlEdit getVariable QGVAR(min);
+    
     if (isNil "_min" || {_min < 0}) then {
         _filter pushBack (toArray "-" select 0);
     };
@@ -68,10 +71,13 @@ _controlsGroup setVariable [QFUNC(value), {
         private _num = parseNumber ctrlText _x;
 
         private _min = _x getVariable QGVAR(min);
+        
         if (!isNil "_min") then {
             _num = _num max _min;
         };
+        
         private _max = _x getVariable QGVAR(max);
+        
         if (!isNil "_max") then {
             _num = _num min _max;
         };

--- a/addons/dialog/functions/fnc_gui_vector.sqf
+++ b/addons/dialog/functions/fnc_gui_vector.sqf
@@ -6,6 +6,8 @@
  * Arguments:
  * 0: Controls Group <CONTROL>
  * 1: Default Value <ARRAY>
+ * 2: Settings <ARRAY>
+ *     0: Allow entering negative numbers <BOOL>
  *
  * Return Value:
  * None
@@ -16,13 +18,18 @@
  * Public: No
  */
 
-params ["_controlsGroup", "_defaultValue"];
+params ["_controlsGroup", "_defaultValue", "_settings"];
+_settings params ["_allowNegativeNumbers"];
 
 // Only allow numeric characters to be entered
 private _fnc_textChanged = {
     params ["_ctrlEdit"];
 
-    private _filter = toArray ".-0123456789";
+    private _filter = toArray ".0123456789";
+    if (_ctrlEdit getVariable [QGVAR(allowNegativeNumbers), true]) then {
+        _filter pushBack (toArray "-");
+    };
+
     private _text = toString (toArray ctrlText _ctrlEdit select {_x in _filter});
     _ctrlEdit ctrlSetText _text;
 };
@@ -31,6 +38,9 @@ private _controls = [];
 
 {
     private _ctrlEdit = _controlsGroup controlsGroupCtrl (IDCS_ROW_VECTOR select _forEachIndex);
+
+    _ctrlEdit setVariable [QGVAR(allowNegativeNumbers), _allowNegativeNumbers];
+
     _ctrlEdit ctrlAddEventHandler ["KeyDown", _fnc_textChanged];
     _ctrlEdit ctrlAddEventHandler ["KeyUp", _fnc_textChanged];
     _ctrlEdit ctrlSetText str _x;

--- a/addons/dialog/gui.hpp
+++ b/addons/dialog/gui.hpp
@@ -259,6 +259,20 @@ class GVAR(Row_VectorXY): GVAR(Row_Base) {
     };
 };
 
+class GVAR(Row_VectorAB): GVAR(Row_VectorXY) {
+    class controls: controls {
+        class Label: Label {};
+        class IconA: IconX {
+            text = "$STR_3DEN_Axis_A";
+        };
+        class EditX: EditX {};
+        class IconB: IconY {
+            text = "$STR_3DEN_Axis_B";
+        };
+        class EditY: EditY {};
+    };
+};
+
 class GVAR(Row_VectorXYZ): GVAR(Row_VectorXY) {
     class controls: controls {
         class Label: Label {};
@@ -283,5 +297,23 @@ class GVAR(Row_VectorXYZ): GVAR(Row_VectorXY) {
             x = QUOTE(POS_W(13.6 + 2 * 12.4/3));
             w = QUOTE(POS_W(12.4/3));
         };
+    };
+};
+
+class GVAR(Row_VectorABC): GVAR(Row_VectorXYZ) {
+    class controls: controls {
+        class Label: Label {};
+        class IconA: IconX {
+            text = "$STR_3DEN_Axis_A";
+        };
+        class EditA: EditX {};
+        class IconB: IconY {
+            text = "$STR_3DEN_Axis_B";
+        };
+        class EditB: EditY {};
+        class IconC: IconZ {
+            text = "C"; // Not localized in A3
+        };
+        class EditC: EditZ {};
     };
 };

--- a/docs/frameworks/dynamic_dialog.md
+++ b/docs/frameworks/dynamic_dialog.md
@@ -211,11 +211,29 @@ The return value type depends on the given default value:
 ### Vector `VECTOR`
 
 A vector input control with support for both XY and XYZ vectors.
-The number of axes displayed depends on the length of the default value array (2 or 3).
+The number of axes displayed depends on the length of the default value array (2 or 3). 
+
+Optionally, the minimum and maximum of each vector component can be set. 
+The user can still set values outside the limits, except for negative numbers if the minimum doesn't allow for it. 
+The input values are only clipped after confirmation.
+
+The vector control can be configured to only accept integer values.
+
+An additional sub-type exists for control type to configure sizes - `VECTOR:SIZE`.
+This sub-type changes the icons from XYZ to ABC. 
+Furthermore, by default, this sub-type only allows for positive values or zero as input.
 
 **Control Specific Argument(s):**
 
 - Default vector &lt;ARRAY&gt;
+- Minimum values &lt;ARRAY&gt;
+    - If this is an empty array, no minimums are set; otherwise, it **must** be the same length as the default vector array (2 or 3).
+    - Use `nil` to set no minimum for a specific vector component.
+    - If set, this will overwrite the default minimums for the `VECTOR:SIZE` sub-type.
+    - Example: `[-1, nil, 0]` The minimum for X is -1, for Y there's none, and for Z it's 0.
+- Maximum values &lt;ARRAY&gt;
+    - Same properties as minimum.
+- Only allow integers &lt;BOOL&gt;
 
 **Return Value:**
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add subtype SIZE to VECTOR. This subtype doesn't allow negative numbers by default.
- Allow setting min and max values for each vector component. The user will still be able to enter values outside the limits. The values are clipped after confirmation. This behavior is the same in 3DEN.
- Add setting to only allow integer values

![Screenshot](https://github.com/user-attachments/assets/645e04f6-1fc6-45f2-8f7a-20930e0501c6)
