### PR TITLE
Add listenable setDamage event when Attribute set

### DIFF
--- a/addons/attributes/initAttributes.inc.sqf
+++ b/addons/attributes/initAttributes.inc.sqf
@@ -49,6 +49,7 @@
         private _damage = 1 - _value;
         {
             _x setDamage _damage;
+            [QEGVAR(common,setDamage), [_x, _damage], _x] call CBA_fnc_targetEvent;
         } forEach SELECTED_OBJECTS;
     },
     {1 - damage _entity},

--- a/addons/context_actions/functions/fnc_repairVehicles.sqf
+++ b/addons/context_actions/functions/fnc_repairVehicles.sqf
@@ -24,4 +24,5 @@ private _vehicles = _this select {
 
 {
     _x setDamage 0;
+    [QEGVAR(common,setDamage), [_x, _damage], _x] call CBA_fnc_targetEvent;
 } forEach _vehicles;

--- a/addons/context_actions/functions/fnc_repairVehicles.sqf
+++ b/addons/context_actions/functions/fnc_repairVehicles.sqf
@@ -24,5 +24,5 @@ private _vehicles = _this select {
 
 {
     _x setDamage 0;
-    [QEGVAR(common,setDamage), [_x, _damage], _x] call CBA_fnc_targetEvent;
+    [QEGVAR(common,setDamage), [_x, 0], _x] call CBA_fnc_targetEvent;
 } forEach _vehicles;


### PR DESCRIPTION
**When merged this pull request will:**
- Adds a setDamage event for mod/mission script compatibility to attributes/initAttributes.inc.sqf and context_actions fnc_repairVehicles.sqf
