### PR TITLE
Common - Delay applying vehicle customization for MP sync

### DIFF
--- a/addons/common/functions/fnc_deserializeObjects.sqf
+++ b/addons/common/functions/fnc_deserializeObjects.sqf
@@ -156,7 +156,8 @@ private _fnc_deserializeVehicle = {
         [_vehicle, "", []] call BIS_fnc_initVehicle;
     } else {
         _customization params ["_textures", "_animations"];
-        [_vehicle, _textures, _animations, true] call BIS_fnc_initVehicle;
+        [{ _this call BIS_fnc_initVehicle; }, [_vehicle, _textures, _animations, true], 1] call cba_fnc_waitAndExecute;
+        
     };
 
     {

--- a/addons/common/functions/fnc_deserializeObjects.sqf
+++ b/addons/common/functions/fnc_deserializeObjects.sqf
@@ -153,11 +153,10 @@ private _fnc_deserializeVehicle = {
     [_vehicle, _inventory] call FUNC(deserializeInventory);
 
     if (_enableRandomization) then {
-        [_vehicle, "", []] call BIS_fnc_initVehicle;
+        [BIS_fnc_initVehicle, [_vehicle, "", []], 1] call CBA_fnc_waitAndExecute;
     } else {
         _customization params ["_textures", "_animations"];
-        [{ _this call BIS_fnc_initVehicle; }, [_vehicle, _textures, _animations, true], 1] call cba_fnc_waitAndExecute;
-        
+        [BIS_fnc_initVehicle, [_vehicle, _textures, _animations, true], 1] call CBA_fnc_waitAndExecute;
     };
 
     {


### PR DESCRIPTION
Textures can fail to sync in MP when this is used. See Problems here: <https://community.bistudio.com/wiki/setObjectTextureGlobal#Description>

**When merged this pull request will:**
- Delay execution of BIS_fnc_initVehicle to allow time for the texture application to sync correctly.
