### PR TITLE
Inventory - Preserve nested container contents when editing

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -53,5 +53,6 @@ SilentSpike
 Timi007
 Toinane
 Tuupertunut
+Venrix
 veteran29
 vivngh

--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -46,6 +46,7 @@ PREP(initListNBoxSorting);
 PREP(initOwnersControl);
 PREP(initSidesControl);
 PREP(initSliderEdit);
+PREP(isContainerItem);
 PREP(isCursorOnMouseArea);
 PREP(isInScreenshotMode);
 PREP(isPlacementActive);

--- a/addons/common/functions/fnc_isContainerItem.sqf
+++ b/addons/common/functions/fnc_isContainerItem.sqf
@@ -1,0 +1,27 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001
+ * Checks if the given item is a container item (uniform, vest, or backpack).
+ *
+ * Arguments:
+ * 0: Item <STRING|OBJECT>
+ *
+ * Return Value:
+ * Is Container Item <BOOL>
+ *
+ * Example:
+ * ["B_AssaultPack_blk"] call zen_common_fnc_isContainerItem
+ *
+ * Public: No
+ */
+
+params [["_item", "", ["", objNull]]];
+
+if (_item isEqualType objNull) then {
+    _item = typeOf _item;
+};
+
+// Inventory item with container storage (uniform or vest)
+getText (configFile >> "CfgWeapons" >> _item >> "ItemInfo" >> "containerClass") != ""
+// Backpack
+|| {getNumber (configFile >> "CfgVehicles" >> _item >> "isBackpack") == 1}

--- a/addons/inventory/config.cpp
+++ b/addons/inventory/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"zen_attributes"};
         author = ECSTRING(main,Author);
-        authors[] = {"mharis001"};
+        authors[] = {"mharis001", "Venrix"};
         url = ECSTRING(main,URL);
         VERSION_CONFIG;
     };

--- a/addons/inventory/config.cpp
+++ b/addons/inventory/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"zen_attributes"};
         author = ECSTRING(main,Author);
-        authors[] = {"mharis001", "Venrix"};
+        authors[] = {"mharis001"};
         url = ECSTRING(main,URL);
         VERSION_CONFIG;
     };

--- a/addons/inventory/functions/fnc_clear.sqf
+++ b/addons/inventory/functions/fnc_clear.sqf
@@ -30,6 +30,17 @@ private _fnc_clear = {
 
     private _cargo = _display getVariable QGVAR(cargo);
     _display setVariable [QGVAR(currentLoad), [_cargo] call FUNC(calculateLoad)];
+
+    // Remove items from the tracked containers as well
+    private _containers = _display getVariable [QGVAR(containers), []];
+
+    {
+        _x params ["_containerType"];
+
+        if (_containerType in _items) then {
+            _containers deleteAt _forEachIndex;
+        };
+    } forEachReversed _containers;
 };
 
 if (_display getVariable [QGVAR(weapon), ""] == "") then {
@@ -38,6 +49,7 @@ if (_display getVariable [QGVAR(weapon), ""] == "") then {
     if (_category == -1) then {
         // No specific category, empty cargo completely
         _display setVariable [QGVAR(cargo), EMPTY_CARGO];
+        _display setVariable [QGVAR(containers), []];
         _display setVariable [QGVAR(currentLoad), 0];
     } else {
         // Specific category selected, get items to remove from the master items list

--- a/addons/inventory/functions/fnc_configure.sqf
+++ b/addons/inventory/functions/fnc_configure.sqf
@@ -28,6 +28,7 @@ _display setVariable [QGVAR(currentLoad), _currentLoad];
 _display setVariable [QGVAR(maximumLoad), maxLoad _object];
 _display setVariable [QGVAR(object), _object];
 _display setVariable [QGVAR(cargo), _cargo];
+_display setVariable [QGVAR(containers), everyContainer _object];
 
 // Adjust display element positions based on the content height
 [_display] call EFUNC(common,initDisplayPositioning);

--- a/addons/inventory/functions/fnc_confirm.sqf
+++ b/addons/inventory/functions/fnc_confirm.sqf
@@ -22,6 +22,13 @@ private _object = _display getVariable QGVAR(object);
 private _cargo  = _display getVariable QGVAR(cargo);
 _cargo params ["_itemCargo", "_weaponCargo", "_magazineCargo", "_backpackCargo"];
 
+// Preserve nested container contents (the cargo model below only tracks backpack classes)
+private _savedContainers = everyContainer _object apply {
+    _x params ["_type", "_container"];
+
+    [_type, _container call EFUNC(common,serializeInventory)]
+};
+
 clearItemCargoGlobal _object;
 clearWeaponCargoGlobal _object;
 clearMagazineCargoGlobal _object;
@@ -50,3 +57,16 @@ _backpackCargo params ["_backpackTypes", "_backpackCounts"];
 {
     _object addBackpackCargoGlobal [_x, _backpackCounts select _forEachIndex];
 } forEach _backpackTypes;
+
+// Restore preserved contents into the re-added backpacks, matching (and consuming) by class
+private _allContainers = everyContainer _object;
+
+{
+    _x params ["_type", "_containerData"];
+
+    private _index = _allContainers findIf {_x select 0 == _type};
+    if (_index != -1) then {
+        private _container = (_allContainers deleteAt _index) select 1;
+        [_container, _containerData] call EFUNC(common,deserializeInventory);
+    };
+} forEach _savedContainers;

--- a/addons/inventory/functions/fnc_confirm.sqf
+++ b/addons/inventory/functions/fnc_confirm.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /*
- * Author: mharis001
+ * Author: mharis001, Venrix
  * Handles confirming the inventory display changes.
  *
  * Arguments:
@@ -19,14 +19,24 @@ params ["_ctrlButtonOK"];
 
 private _display = ctrlParent _ctrlButtonOK;
 private _object = _display getVariable QGVAR(object);
-private _cargo  = _display getVariable QGVAR(cargo);
+private _cargo = _display getVariable QGVAR(cargo);
 _cargo params ["_itemCargo", "_weaponCargo", "_magazineCargo", "_backpackCargo"];
 
-// Preserve nested container contents (the cargo model below only tracks backpack classes)
-private _savedContainers = everyContainer _object apply {
+// Preserve original nested container contents that survived editor operations
+private _preservedContainers = _display getVariable QGVAR(containers) apply {
     _x params ["_type", "_container"];
 
-    [_type, _container call EFUNC(common,serializeInventory)]
+    [
+        _type,
+        if (isNull _container) then {
+            // Needed to properly handle newly added containers with config defined inventories
+            // Otherwise, their contents would be cleared and never added back
+            // This ensures that their inventories remain untouched
+            []
+        } else {
+            _container call EFUNC(common,serializeInventory)
+        }
+    ]
 };
 
 clearItemCargoGlobal _object;
@@ -58,15 +68,21 @@ _backpackCargo params ["_backpackTypes", "_backpackCounts"];
     _object addBackpackCargoGlobal [_x, _backpackCounts select _forEachIndex];
 } forEach _backpackTypes;
 
-// Restore preserved contents into the re-added backpacks, matching (and consuming) by class
-private _allContainers = everyContainer _object;
+// Restore preserved contents into the re-added containers, matching (and consuming) by class
+private _everyContainer = everyContainer _object;
 
 {
-    _x params ["_type", "_containerData"];
+    _x params ["_type", "_data"];
 
-    private _index = _allContainers findIf {_x select 0 == _type};
+    private _index = _everyContainer findIf {_x select 0 == _type};
+
     if (_index != -1) then {
-        private _container = (_allContainers deleteAt _index) select 1;
-        [_container, _containerData] call EFUNC(common,deserializeInventory);
+        private _container = _everyContainer deleteAt _index select 1;
+
+        // Consume new containers too so duplicate classes remain aligned,
+        // but don't restore anything into them
+        if (_data isNotEqualTo []) then {
+            [_container, _data] call EFUNC(common,deserializeInventory);
+        };
     };
-} forEach _savedContainers;
+} forEach _preservedContainers;

--- a/addons/inventory/functions/fnc_modify.sqf
+++ b/addons/inventory/functions/fnc_modify.sqf
@@ -74,6 +74,37 @@ if (_count > 0) then {
     _counts deleteAt _index;
 };
 
+// Update tracked containers if needed
+private _isContainer = _item call EFUNC(common,isContainerItem);
+
+if (_isContainer && {_amount != 0}) then {
+    private _containers = _display getVariable [QGVAR(containers), []];
+
+    if (_amount > 0) then {
+        // Newly added containers do not have an existing inventory
+        for "_i" from 1 to _amount do {
+            _containers pushBack [_item, objNull];
+        };
+    } else {
+        // Remove the most recently added/matched instance
+        // LIFO gives useful semantics for adding and then removing (or vice versa)
+        private _amountToRemove = -_amount;
+
+        {
+            _x params ["_containerType"];
+
+            if (_containerType == _item) then {
+                _containers deleteAt _forEachIndex;
+                _amountToRemove = _amountToRemove - 1;
+
+                if (_amountToRemove == 0) then {
+                    break;
+                };
+            };
+        } forEachReversed _containers;
+    };
+};
+
 // Update the item's row in the list
 private _alpha = [ALPHA_NONE, ALPHA_SOME] select (_count > 0);
 _ctrlList lnbSetValue [[_currentRow, 2], _count];

--- a/addons/inventory/functions/fnc_reset.sqf
+++ b/addons/inventory/functions/fnc_reset.sqf
@@ -23,6 +23,25 @@ private _object = _display getVariable QGVAR(object);
 private _cargo = _object call EFUNC(common,getDefaultInventory);
 _display setVariable [QGVAR(cargo), _cargo];
 
+// Track default container items as new containers with no preserved contents
+private _containers = [];
+
+{
+    _x params ["_types", "_counts"];
+
+    {
+        if (_x call EFUNC(common,isContainerItem)) then {
+            private _count = _counts select _forEachIndex;
+
+            for "_i" from 1 to _count do {
+                _containers pushBack [_x, objNull];
+            };
+        };
+    } forEach _types;
+} forEach _cargo;
+
+_display setVariable [QGVAR(containers), _containers];
+
 // Calculate the current load of the cargo
 private _load = [_cargo] call FUNC(calculateLoad);
 _display setVariable [QGVAR(currentLoad), _load];


### PR DESCRIPTION
**When merged this pull request will:**
- Preserve the contents of containers (e.g. backpacks) inside a vehicle when its inventory is edited via the 'edit inventory' dialog
- Fix items inside those containers being lost on confirm (see video)

https://github.com/user-attachments/assets/ff3017e7-dec5-4678-8701-7051c5dba244



